### PR TITLE
Sanitize mp4 paths in HTML and JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 
       <!-- Vidéo source, cachée -->
       <video id="background-video" preload="auto" autoplay loop style="display: none;">
-        <source src="videos/VideoExports/Archive_001_LoganSamawithJME&NewhamGeneralsKissOct5th2010.mp4" type="video/mp4">
+        <source src="videos/VideoExports/Archive_001_LoganSama_JME_NewhamGenerals.mp4" type="video/mp4">
       </video>
 
       

--- a/js/dataLinker.js
+++ b/js/dataLinker.js
@@ -4,15 +4,15 @@ const sourceElement = videoElement.querySelector("source");
 
 const videoList = [
   // {
-  //   file: "videos/VideoExports/Archive_001_LoganSamawithJME&NewhamGeneralsKissOct5th2010.mp4",
+  //   file: "videos/VideoExports/Archive_001_LoganSama_JME_NewhamGenerals.mp4",
   //   archive: "ARCHIVE_001_data.json"
   // },
   // {
-  //   file: "videos/VideoExports/Archive_003_LoganSamaKISSPRESENTSftSkepta,JME,Jammer,Frisco&Shorty(BoyBetterKnow)Jun17th2011.mp4",
+  //   file: "videos/VideoExports/Archive_003_LoganSama_Skepta_JME_Jammer_Frisco_Shorty.mp4",
   //   archive: "ARCHIVE_003_data.json"
   // },
   {
-    file: "videos/VideoExports/Archive_007_TempaT,Skepta&JMEontheLoganSamashow_02_03_09Part1_2(HD).mp4",
+    file: "videos/VideoExports/Archive_007_TempaT_Skepta_JME_LoganSama.mp4",
     archive: "ARCHIVE_007_data.json"
   }
 ];

--- a/test-video.html
+++ b/test-video.html
@@ -6,7 +6,7 @@
 </head>
 <body>
   <h1>Test vidéo locale</h1>
-  <video src="videos/Archive_007_TempaT,Skepta&JMEontheLoganSamashow_02_03_09Part1_2(HD).mp4" 
-         controls autoplay width="800"></video>
+  <video src="videos/Archive_007_TempaT_Skepta_JME_LoganSama.mp4"
+           controls autoplay width="800"></video>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update `<source>` in index.html to simplified video filename
- standardize filenames in dataLinker.js
- simplify path in test-video.html

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844be60bcf88326b100fff498b7925f