### PR TITLE
Improve segment formatting

### DIFF
--- a/data/ARCHIVE_001_data.json
+++ b/data/ARCHIVE_001_data.json
@@ -1,6 +1,6 @@
 {
-  "title": "Kiss FM 2008 – Logan Sama After Hours Show",
-  "duration": 869.00,
+  "title": "Kiss FM 2008 \u2013 Logan Sama After Hours Show",
+  "duration": 869.0,
   "instrumentals": [
     {
       "start": 0.0,
@@ -60,10 +60,9 @@
   "reloads": [],
   "segments": [
     {
-      "id": 0,
       "start": 0.0,
-      "end": 9.78,
-      "text": "Yeah! Tired to do that, sorry. Hey! Logan loves this one. Dude,",
+      "end": 7.4,
+      "text": "Yeah! Tired to do that, sorry. Hey!",
       "words": [
         {
           "word": "Yeah!",
@@ -99,7 +98,15 @@
           "word": "Hey!",
           "start": 7.04,
           "end": 7.4
-        },
+        }
+      ],
+      "speaker": "unknown"
+    },
+    {
+      "start": 8.14,
+      "end": 9.78,
+      "text": "Logan loves this one. Dude,",
+      "words": [
         {
           "word": "Logan",
           "start": 8.14,
@@ -129,10 +136,9 @@
       "speaker": "unknown"
     },
     {
-      "id": 1,
       "start": 9.92,
-      "end": 13.66,
-      "text": "forever. Shout out to Tubby, Vigo, Foxy. So, we've got the new",
+      "end": 11.88,
+      "text": "forever. Shout out to Tubby, Vigo, Foxy.",
       "words": [
         {
           "word": "forever.",
@@ -168,7 +174,15 @@
           "word": "Foxy.",
           "start": 11.38,
           "end": 11.88
-        },
+        }
+      ],
+      "speaker": "Logan Sama"
+    },
+    {
+      "start": 12.88,
+      "end": 13.66,
+      "text": "So, we've got the new",
+      "words": [
         {
           "word": "So,",
           "start": 12.88,
@@ -198,10 +212,9 @@
       "speaker": "Logan Sama"
     },
     {
-      "id": 2,
       "start": 13.66,
-      "end": 16.78,
-      "text": "generals inside the studio. We have got Jeremy inside the studio. So,",
+      "end": 14.9,
+      "text": "generals inside the studio.",
       "words": [
         {
           "word": "generals",
@@ -222,7 +235,15 @@
           "word": "studio.",
           "start": 14.6,
           "end": 14.9
-        },
+        }
+      ],
+      "speaker": "Logan Sama"
+    },
+    {
+      "start": 15.24,
+      "end": 16.78,
+      "text": "We have got Jeremy inside the studio. So,",
+      "words": [
         {
           "word": "We",
           "start": 15.24,
@@ -267,10 +288,9 @@
       "speaker": "Logan Sama"
     },
     {
-      "id": 3,
       "start": 16.86,
-      "end": 20.4,
-      "text": "Tug of the Fourth is a massive day. Like blam. And we've",
+      "end": 18.14,
+      "text": "Tug of the Fourth is a massive day.",
       "words": [
         {
           "word": "Tug",
@@ -311,7 +331,15 @@
           "word": "day.",
           "start": 17.82,
           "end": 18.14
-        },
+        }
+      ],
+      "speaker": "Logan Sama"
+    },
+    {
+      "start": 18.900000000000002,
+      "end": 20.4,
+      "text": "Like blam. And we've",
+      "words": [
         {
           "word": "Like",
           "start": 18.900000000000002,
@@ -336,10 +364,9 @@
       "speaker": "Logan Sama"
     },
     {
-      "id": 4,
       "start": 20.4,
-      "end": 22.28,
-      "text": "got 60 minutes of this show, which means I'm going to hand",
+      "end": 22.04,
+      "text": "got 60 minutes of this show, which means I'm",
       "words": [
         {
           "word": "got",
@@ -385,7 +412,15 @@
           "word": "I'm",
           "start": 21.82,
           "end": 22.04
-        },
+        }
+      ],
+      "speaker": "Logan Sama"
+    },
+    {
+      "start": 22.04,
+      "end": 22.28,
+      "text": "going to hand",
+      "words": [
         {
           "word": "going",
           "start": 22.04,
@@ -405,10 +440,9 @@
       "speaker": "Logan Sama"
     },
     {
-      "id": 5,
       "start": 22.28,
-      "end": 25.8,
-      "text": "it straight over to you now. Everyone ready? Ready! Yeah, let's go.",
+      "end": 24.96,
+      "text": "it straight over to you now. Everyone ready? Ready!",
       "words": [
         {
           "word": "it",
@@ -454,7 +488,15 @@
           "word": "Ready!",
           "start": 24.64,
           "end": 24.96
-        },
+        }
+      ],
+      "speaker": "Logan Sama"
+    },
+    {
+      "start": 25.32,
+      "end": 25.8,
+      "text": "Yeah, let's go.",
+      "words": [
         {
           "word": "Yeah,",
           "start": 25.32,
@@ -474,10 +516,9 @@
       "speaker": "Logan Sama"
     },
     {
-      "id": 6,
       "start": 31.08,
-      "end": 34.66,
-      "text": "No one's ready to go first. There is the head nodding team.",
+      "end": 32.82,
+      "text": "No one's ready to go first.",
       "words": [
         {
           "word": "No",
@@ -508,7 +549,15 @@
           "word": "first.",
           "start": 32.36,
           "end": 32.82
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 33.1,
+      "end": 35.9,
+      "text": "There is the head nodding team. Yeah.",
+      "words": [
         {
           "word": "There",
           "start": 33.1,
@@ -538,21 +587,20 @@
           "word": "team.",
           "start": 34.36,
           "end": 34.66
+        },
+        {
+          "word": "Yeah.",
+          "start": 35.34,
+          "end": 35.9
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 7,
-      "start": 35.34,
-      "end": 39.42,
-      "text": "Yeah. He's going to bop for six minutes, Logan. Oh my God.",
+      "start": 36.54,
+      "end": 38.2,
+      "text": "He's going to bop for six minutes, Logan.",
       "words": [
-        {
-          "word": "Yeah.",
-          "start": 35.34,
-          "end": 35.9
-        },
         {
           "word": "He's",
           "start": 36.54,
@@ -592,7 +640,15 @@
           "word": "Logan.",
           "start": 38.04,
           "end": 38.2
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 38.48,
+      "end": 42.0,
+      "text": "Oh my God. Yo!",
+      "words": [
         {
           "word": "Oh",
           "start": 38.48,
@@ -607,21 +663,20 @@
           "word": "God.",
           "start": 39.18,
           "end": 39.42
+        },
+        {
+          "word": "Yo!",
+          "start": 41.44,
+          "end": 42.0
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 8,
-      "start": 41.44,
-      "end": 46.78,
-      "text": "Yo! Blam out now. Bag of grease out now. It's all out",
+      "start": 42.88,
+      "end": 43.96,
+      "text": "Blam out now.",
       "words": [
-        {
-          "word": "Yo!",
-          "start": 41.44,
-          "end": 42.0
-        },
         {
           "word": "Blam",
           "start": 42.88,
@@ -636,7 +691,15 @@
           "word": "now.",
           "start": 43.66,
           "end": 43.96
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 44.18,
+      "end": 45.62,
+      "text": "Bag of grease out now.",
+      "words": [
         {
           "word": "Bag",
           "start": 44.18,
@@ -661,7 +724,15 @@
           "word": "now.",
           "start": 45.22,
           "end": 45.62
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 46.24,
+      "end": 47.06,
+      "text": "It's all out now.",
+      "words": [
         {
           "word": "It's",
           "start": 46.24,
@@ -676,21 +747,20 @@
           "word": "out",
           "start": 46.58,
           "end": 46.78
+        },
+        {
+          "word": "now.",
+          "start": 46.78,
+          "end": 47.06
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 9,
-      "start": 46.78,
-      "end": 53.02,
-      "text": "now. Cop it all. Support the cause, it's real. Real music. Yo!",
+      "start": 47.28,
+      "end": 47.8,
+      "text": "Cop it all.",
       "words": [
-        {
-          "word": "now.",
-          "start": 46.78,
-          "end": 47.06
-        },
         {
           "word": "Cop",
           "start": 47.28,
@@ -705,7 +775,15 @@
           "word": "all.",
           "start": 47.58,
           "end": 47.8
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 48.62,
+      "end": 54.7,
+      "text": "Support the cause, it's real. Real music. Yo! Listen.",
+      "words": [
         {
           "word": "Support",
           "start": 48.62,
@@ -745,21 +823,20 @@
           "word": "Yo!",
           "start": 52.56,
           "end": 53.02
+        },
+        {
+          "word": "Listen.",
+          "start": 54.14,
+          "end": 54.7
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 10,
-      "start": 54.14,
-      "end": 60.54,
-      "text": "Listen. It's Butsy again. Stuff it twice, can't look see again. Don't",
+      "start": 57.12,
+      "end": 58.28,
+      "text": "It's Butsy again.",
       "words": [
-        {
-          "word": "Listen.",
-          "start": 54.14,
-          "end": 54.7
-        },
         {
           "word": "It's",
           "start": 57.12,
@@ -774,7 +851,15 @@
           "word": "again.",
           "start": 58.0,
           "end": 58.28
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 58.28,
+      "end": 60.54,
+      "text": "Stuff it twice, can't look see again. Don't",
+      "words": [
         {
           "word": "Stuff",
           "start": 58.28,
@@ -819,10 +904,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 11,
       "start": 60.54,
-      "end": 62.8,
-      "text": "know what with Butsy again. It's bare hooks to get your phone.",
+      "end": 61.64,
+      "text": "know what with Butsy again.",
       "words": [
         {
           "word": "know",
@@ -848,7 +932,15 @@
           "word": "again.",
           "start": 61.4,
           "end": 61.64
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 61.76,
+      "end": 63.46,
+      "text": "It's bare hooks to get your phone. Butsy again.",
+      "words": [
         {
           "word": "It's",
           "start": 61.76,
@@ -883,16 +975,7 @@
           "word": "phone.",
           "start": 62.56,
           "end": 62.8
-        }
-      ],
-      "speaker": "Footsie"
-    },
-    {
-      "id": 12,
-      "start": 62.9,
-      "end": 66.36,
-      "text": "Butsy again. And again, yeah. It's Butsy again. Stuff it twice, can't",
-      "words": [
+        },
         {
           "word": "Butsy",
           "start": 62.9,
@@ -902,7 +985,15 @@
           "word": "again.",
           "start": 63.18,
           "end": 63.46
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 63.62,
+      "end": 64.06,
+      "text": "And again, yeah.",
+      "words": [
         {
           "word": "And",
           "start": 63.62,
@@ -917,7 +1008,15 @@
           "word": "yeah.",
           "start": 63.98,
           "end": 64.06
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 64.36,
+      "end": 65.16,
+      "text": "It's Butsy again.",
+      "words": [
         {
           "word": "It's",
           "start": 64.36,
@@ -932,7 +1031,15 @@
           "word": "again.",
           "start": 64.84,
           "end": 65.16
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 65.46,
+      "end": 66.36,
+      "text": "Stuff it twice, can't",
+      "words": [
         {
           "word": "Stuff",
           "start": 65.46,
@@ -957,10 +1064,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 13,
       "start": 66.36,
-      "end": 69.04,
-      "text": "look see now. They're not on it. They don't want it. Watch",
+      "end": 66.9,
+      "text": "look see now.",
       "words": [
         {
           "word": "look",
@@ -976,7 +1082,15 @@
           "word": "now.",
           "start": 66.6,
           "end": 66.9
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 67.2,
+      "end": 67.84,
+      "text": "They're not on it.",
+      "words": [
         {
           "word": "They're",
           "start": 67.2,
@@ -996,7 +1110,15 @@
           "word": "it.",
           "start": 67.7,
           "end": 67.84
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 68.02,
+      "end": 69.04,
+      "text": "They don't want it. Watch",
+      "words": [
         {
           "word": "They",
           "start": 68.02,
@@ -1026,10 +1148,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 14,
       "start": 69.04,
-      "end": 72.08,
-      "text": "the Haramika boy run. You get bare right hooks. Bare left hooks.",
+      "end": 69.92,
+      "text": "the Haramika boy run.",
       "words": [
         {
           "word": "the",
@@ -1050,7 +1171,15 @@
           "word": "run.",
           "start": 69.64,
           "end": 69.92
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 70.16,
+      "end": 71.16,
+      "text": "You get bare right hooks.",
+      "words": [
         {
           "word": "You",
           "start": 70.16,
@@ -1075,7 +1204,15 @@
           "word": "hooks.",
           "start": 70.92,
           "end": 71.16
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 71.48,
+      "end": 72.08,
+      "text": "Bare left hooks.",
+      "words": [
         {
           "word": "Bare",
           "start": 71.48,
@@ -1095,10 +1232,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 15,
       "start": 72.44,
-      "end": 75.24,
-      "text": "Bare upper cuts. Bare head behind. Left the face of bare cuts.",
+      "end": 72.9,
+      "text": "Bare upper cuts.",
       "words": [
         {
           "word": "Bare",
@@ -1114,7 +1250,15 @@
           "word": "cuts.",
           "start": 72.68,
           "end": 72.9
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 73.28,
+      "end": 73.82,
+      "text": "Bare head behind.",
+      "words": [
         {
           "word": "Bare",
           "start": 73.28,
@@ -1129,7 +1273,15 @@
           "word": "behind.",
           "start": 73.54,
           "end": 73.82
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 74.44,
+      "end": 75.24,
+      "text": "Left the face of bare cuts.",
+      "words": [
         {
           "word": "Left",
           "start": 74.44,
@@ -1164,10 +1316,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 16,
       "start": 75.24,
-      "end": 77.62,
-      "text": "Don't let me get deep and dry. But then you'll get bare",
+      "end": 76.74,
+      "text": "Don't let me get deep and dry.",
       "words": [
         {
           "word": "Don't",
@@ -1203,7 +1354,15 @@
           "word": "dry.",
           "start": 76.54,
           "end": 76.74
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 76.9,
+      "end": 78.12,
+      "text": "But then you'll get bare right hooks.",
+      "words": [
         {
           "word": "But",
           "start": 76.9,
@@ -1228,16 +1387,7 @@
           "word": "bare",
           "start": 77.4,
           "end": 77.62
-        }
-      ],
-      "speaker": "Footsie"
-    },
-    {
-      "id": 17,
-      "start": 77.62,
-      "end": 81.42,
-      "text": "right hooks. Bare left hooks. Bare upper cuts. Bare head behind. Left",
-      "words": [
+        },
         {
           "word": "right",
           "start": 77.62,
@@ -1247,7 +1397,15 @@
           "word": "hooks.",
           "start": 77.8,
           "end": 78.12
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 78.4,
+      "end": 78.98,
+      "text": "Bare left hooks.",
+      "words": [
         {
           "word": "Bare",
           "start": 78.4,
@@ -1262,7 +1420,15 @@
           "word": "hooks.",
           "start": 78.68,
           "end": 78.98
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 79.2,
+      "end": 79.82,
+      "text": "Bare upper cuts.",
+      "words": [
         {
           "word": "Bare",
           "start": 79.2,
@@ -1277,7 +1443,15 @@
           "word": "cuts.",
           "start": 79.5,
           "end": 79.82
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 80.12,
+      "end": 81.42,
+      "text": "Bare head behind. Left",
+      "words": [
         {
           "word": "Bare",
           "start": 80.12,
@@ -1302,10 +1476,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 18,
       "start": 81.42,
-      "end": 85.06,
-      "text": "the face of bare cut. Hey, don't beat my job. I'm not",
+      "end": 82.2,
+      "text": "the face of bare cut.",
       "words": [
         {
           "word": "the",
@@ -1331,7 +1504,15 @@
           "word": "cut.",
           "start": 82.08,
           "end": 82.2
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 82.4,
+      "end": 85.06,
+      "text": "Hey, don't beat my job. I'm not",
+      "words": [
         {
           "word": "Hey,",
           "start": 82.4,
@@ -1371,10 +1552,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 19,
       "start": 85.06,
-      "end": 88.64,
-      "text": "a liberal father. Name an MC that rich father. Then you really",
+      "end": 85.84,
+      "text": "a liberal father.",
       "words": [
         {
           "word": "a",
@@ -1390,7 +1570,15 @@
           "word": "father.",
           "start": 85.32,
           "end": 85.84
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 85.84,
+      "end": 87.62,
+      "text": "Name an MC that rich father.",
+      "words": [
         {
           "word": "Name",
           "start": 85.84,
@@ -1420,7 +1608,15 @@
           "word": "father.",
           "start": 87.22,
           "end": 87.62
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 88.2,
+      "end": 88.64,
+      "text": "Then you really",
+      "words": [
         {
           "word": "Then",
           "start": 88.2,
@@ -1440,10 +1636,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 20,
       "start": 88.64,
-      "end": 91.82,
-      "text": "are my partner. Cause you really are my partner. Ain't got time",
+      "end": 89.32,
+      "text": "are my partner.",
       "words": [
         {
           "word": "are",
@@ -1459,7 +1654,15 @@
           "word": "partner.",
           "start": 88.92,
           "end": 89.32
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 89.7,
+      "end": 91.02,
+      "text": "Cause you really are my partner.",
+      "words": [
         {
           "word": "Cause",
           "start": 89.7,
@@ -1489,7 +1692,15 @@
           "word": "partner.",
           "start": 90.6,
           "end": 91.02
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 91.34,
+      "end": 91.82,
+      "text": "Ain't got time",
+      "words": [
         {
           "word": "Ain't",
           "start": 91.34,
@@ -1509,10 +1720,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 21,
       "start": 91.82,
-      "end": 94.86,
-      "text": "for mucking around. No one to maintain things that got done. Getting",
+      "end": 92.56,
+      "text": "for mucking around.",
       "words": [
         {
           "word": "for",
@@ -1528,7 +1738,15 @@
           "word": "around.",
           "start": 92.26,
           "end": 92.56
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 92.98,
+      "end": 94.86,
+      "text": "No one to maintain things that got done. Getting",
+      "words": [
         {
           "word": "No",
           "start": 92.98,
@@ -1578,10 +1796,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 22,
       "start": 94.86,
-      "end": 97.56,
-      "text": "around, getting around, getting around, getting around, the dick tent to the",
+      "end": 97.14,
+      "text": "around, getting around, getting around, getting around, the dick",
       "words": [
         {
           "word": "around,",
@@ -1627,7 +1844,15 @@
           "word": "dick",
           "start": 96.94,
           "end": 97.14
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 97.14,
+      "end": 97.56,
+      "text": "tent to the",
+      "words": [
         {
           "word": "tent",
           "start": 97.14,
@@ -1647,10 +1872,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 23,
       "start": 97.56,
-      "end": 100.02,
-      "text": "tan like brown. The dick tent to the tan like crack, you're",
+      "end": 98.26,
+      "text": "tan like brown.",
       "words": [
         {
           "word": "tan",
@@ -1666,7 +1890,15 @@
           "word": "brown.",
           "start": 97.96,
           "end": 98.26
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 98.54,
+      "end": 100.02,
+      "text": "The dick tent to the tan like crack, you're",
+      "words": [
         {
           "word": "The",
           "start": 98.54,
@@ -1716,10 +1948,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 24,
       "start": 100.02,
-      "end": 103.0,
-      "text": "the tall soldier. It's for the back. The inside, the inside, the",
+      "end": 100.66,
+      "text": "the tall soldier.",
       "words": [
         {
           "word": "the",
@@ -1735,7 +1966,15 @@
           "word": "soldier.",
           "start": 100.28,
           "end": 100.66
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 101.06,
+      "end": 101.68,
+      "text": "It's for the back.",
+      "words": [
         {
           "word": "It's",
           "start": 101.06,
@@ -1755,7 +1994,15 @@
           "word": "back.",
           "start": 101.38,
           "end": 101.68
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 102.02,
+      "end": 103.28,
+      "text": "The inside, the inside, the back.",
+      "words": [
         {
           "word": "The",
           "start": 102.02,
@@ -1780,21 +2027,20 @@
           "word": "the",
           "start": 102.8,
           "end": 103.0
+        },
+        {
+          "word": "back.",
+          "start": 103.0,
+          "end": 103.28
         }
       ],
       "speaker": "D Double E"
     },
     {
-      "id": 25,
-      "start": 103.0,
-      "end": 104.84,
-      "text": "back. Keep up with the time, think I'm who I'm for the",
+      "start": 103.38,
+      "end": 104.6,
+      "text": "Keep up with the time, think I'm who I'm",
       "words": [
-        {
-          "word": "back.",
-          "start": 103.0,
-          "end": 103.28
-        },
         {
           "word": "Keep",
           "start": 103.38,
@@ -1839,7 +2085,15 @@
           "word": "I'm",
           "start": 104.56,
           "end": 104.6
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 104.6,
+      "end": 105.14,
+      "text": "for the back.",
+      "words": [
         {
           "word": "for",
           "start": 104.6,
@@ -1849,21 +2103,20 @@
           "word": "the",
           "start": 104.72,
           "end": 104.84
+        },
+        {
+          "word": "back.",
+          "start": 104.84,
+          "end": 105.14
         }
       ],
       "speaker": "D Double E"
     },
     {
-      "id": 26,
-      "start": 104.84,
-      "end": 107.2,
-      "text": "back. I'm boxing some more, so I'm gonna get in my come",
+      "start": 105.54,
+      "end": 106.94,
+      "text": "I'm boxing some more, so I'm gonna get in",
       "words": [
-        {
-          "word": "back.",
-          "start": 104.84,
-          "end": 105.14
-        },
         {
           "word": "I'm",
           "start": 105.54,
@@ -1908,7 +2161,15 @@
           "word": "in",
           "start": 106.8,
           "end": 106.94
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 106.94,
+      "end": 108.02,
+      "text": "my come and eat my toes.",
+      "words": [
         {
           "word": "my",
           "start": 106.94,
@@ -1918,16 +2179,7 @@
           "word": "come",
           "start": 107.06,
           "end": 107.2
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 27,
-      "start": 107.2,
-      "end": 109.8,
-      "text": "and eat my toes. Come and eat plan and your friend cross.",
-      "words": [
+        },
         {
           "word": "and",
           "start": 107.2,
@@ -1947,7 +2199,15 @@
           "word": "toes.",
           "start": 107.76,
           "end": 108.02
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 108.38,
+      "end": 109.8,
+      "text": "Come and eat plan and your friend cross.",
+      "words": [
         {
           "word": "Come",
           "start": 108.38,
@@ -1992,10 +2252,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 28,
       "start": 110.08,
-      "end": 114.32,
-      "text": "So from the winner, my truck, my heart. I'm like an intervention.",
+      "end": 112.0,
+      "text": "So from the winner, my truck, my heart.",
       "words": [
         {
           "word": "So",
@@ -2036,7 +2295,15 @@
           "word": "heart.",
           "start": 111.62,
           "end": 112.0
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 113.2,
+      "end": 114.32,
+      "text": "I'm like an intervention.",
+      "words": [
         {
           "word": "I'm",
           "start": 113.2,
@@ -2061,10 +2328,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 29,
       "start": 114.32,
-      "end": 118.44,
-      "text": "Silence, sniper, filled attention. No silence, sub -bear attention. You could be",
+      "end": 116.1,
+      "text": "Silence, sniper, filled attention.",
       "words": [
         {
           "word": "Silence,",
@@ -2085,7 +2351,15 @@
           "word": "attention.",
           "start": 115.7,
           "end": 116.1
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 116.3,
+      "end": 117.74,
+      "text": "No silence, sub -bear attention.",
+      "words": [
         {
           "word": "No",
           "start": 116.3,
@@ -2110,7 +2384,15 @@
           "word": "attention.",
           "start": 117.38,
           "end": 117.74
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 118.06,
+      "end": 118.44,
+      "text": "You could be",
+      "words": [
         {
           "word": "You",
           "start": 118.06,
@@ -2130,10 +2412,9 @@
       "speaker": "JME"
     },
     {
-      "id": 30,
       "start": 118.44,
-      "end": 121.82,
-      "text": "young or old, collecting your gyro or receiving pension. You could be",
+      "end": 121.16,
+      "text": "young or old, collecting your gyro or receiving pension.",
       "words": [
         {
           "word": "young",
@@ -2179,7 +2460,15 @@
           "word": "pension.",
           "start": 120.78,
           "end": 121.16
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 121.46,
+      "end": 121.82,
+      "text": "You could be",
+      "words": [
         {
           "word": "You",
           "start": 121.46,
@@ -2199,10 +2488,9 @@
       "speaker": "JME"
     },
     {
-      "id": 31,
       "start": 121.82,
-      "end": 125.14,
-      "text": "a little kid in detention. You man get smoked like Benson. Head",
+      "end": 122.84,
+      "text": "a little kid in detention.",
       "words": [
         {
           "word": "a",
@@ -2228,7 +2516,15 @@
           "word": "detention.",
           "start": 122.48,
           "end": 122.84
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 123.34,
+      "end": 125.14,
+      "text": "You man get smoked like Benson. Head",
+      "words": [
         {
           "word": "You",
           "start": 123.34,
@@ -2268,10 +2564,9 @@
       "speaker": "JME"
     },
     {
-      "id": 32,
       "start": 125.14,
-      "end": 128.58,
-      "text": "up way too many dimension. Come like a cranium convention. You don't",
+      "end": 126.22,
+      "text": "up way too many dimension.",
       "words": [
         {
           "word": "up",
@@ -2297,7 +2592,15 @@
           "word": "dimension.",
           "start": 125.9,
           "end": 126.22
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 126.58,
+      "end": 128.58,
+      "text": "Come like a cranium convention. You don't",
+      "words": [
         {
           "word": "Come",
           "start": 126.58,
@@ -2337,10 +2640,9 @@
       "speaker": "JME"
     },
     {
-      "id": 33,
       "start": 128.58,
-      "end": 133.9,
-      "text": "hedge that's water retention. So, check out the new invention. Slap man",
+      "end": 129.74,
+      "text": "hedge that's water retention.",
       "words": [
         {
           "word": "hedge",
@@ -2361,7 +2663,15 @@
           "word": "retention.",
           "start": 129.22,
           "end": 129.74
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 131.52,
+      "end": 133.9,
+      "text": "So, check out the new invention. Slap man",
+      "words": [
         {
           "word": "So,",
           "start": 131.52,
@@ -2406,10 +2716,9 @@
       "speaker": "JME"
     },
     {
-      "id": 34,
       "start": 133.9,
-      "end": 136.86,
-      "text": "into the fourth dimension. You know I'm dirty and stank, but I'm",
+      "end": 134.9,
+      "text": "into the fourth dimension.",
       "words": [
         {
           "word": "into",
@@ -2430,7 +2739,15 @@
           "word": "dimension.",
           "start": 134.5,
           "end": 134.9
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 135.28,
+      "end": 136.86,
+      "text": "You know I'm dirty and stank, but I'm",
+      "words": [
         {
           "word": "You",
           "start": 135.28,
@@ -2475,10 +2792,9 @@
       "speaker": "JME"
     },
     {
-      "id": 35,
       "start": 136.86,
-      "end": 140.42,
-      "text": "behind these two like Mr. Depplin. Say, look, I'm going with the",
+      "end": 138.4,
+      "text": "behind these two like Mr. Depplin.",
       "words": [
         {
           "word": "behind",
@@ -2509,7 +2825,15 @@
           "word": "Depplin.",
           "start": 138.04,
           "end": 138.4
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 138.62,
+      "end": 140.42,
+      "text": "Say, look, I'm going with the",
+      "words": [
         {
           "word": "Say,",
           "start": 138.62,
@@ -2544,10 +2868,9 @@
       "speaker": "JME"
     },
     {
-      "id": 36,
       "start": 140.42,
-      "end": 143.34,
-      "text": "rats. Flip the food chain, eating the cats. Cats with food and",
+      "end": 142.34,
+      "text": "rats. Flip the food chain, eating the cats.",
       "words": [
         {
           "word": "rats.",
@@ -2588,7 +2911,15 @@
           "word": "cats.",
           "start": 142.08,
           "end": 142.34
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 142.34,
+      "end": 143.34,
+      "text": "Cats with food and",
+      "words": [
         {
           "word": "Cats",
           "start": 142.34,
@@ -2613,10 +2944,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 37,
       "start": 143.34,
-      "end": 146.24,
-      "text": "cats with B. Cats with white and cats with B. None of",
+      "end": 144.04,
+      "text": "cats with B.",
       "words": [
         {
           "word": "cats",
@@ -2632,7 +2962,15 @@
           "word": "B.",
           "start": 143.76,
           "end": 144.04
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 144.24,
+      "end": 146.24,
+      "text": "Cats with white and cats with B. None of",
+      "words": [
         {
           "word": "Cats",
           "start": 144.24,
@@ -2682,10 +3020,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 38,
       "start": 146.24,
-      "end": 148.22,
-      "text": "these cats can't f with me. They can get done, no, I",
+      "end": 147.38,
+      "text": "these cats can't f with me.",
       "words": [
         {
           "word": "these",
@@ -2716,7 +3053,15 @@
           "word": "me.",
           "start": 147.18,
           "end": 147.38
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 147.48,
+      "end": 148.22,
+      "text": "They can get done, no, I",
+      "words": [
         {
           "word": "They",
           "start": 147.48,
@@ -2751,10 +3096,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 39,
       "start": 148.22,
-      "end": 150.38,
-      "text": "beg at F and G. What do I get by the N",
+      "end": 149.12,
+      "text": "beg at F and G.",
       "words": [
         {
           "word": "beg",
@@ -2780,7 +3124,15 @@
           "word": "G.",
           "start": 148.88,
           "end": 149.12
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 149.5,
+      "end": 150.38,
+      "text": "What do I get by the N",
+      "words": [
         {
           "word": "What",
           "start": 149.5,
@@ -2820,10 +3172,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 40,
       "start": 150.38,
-      "end": 152.32,
-      "text": "in the G? And I can't forget by the N in the",
+      "end": 150.8,
+      "text": "in the G?",
       "words": [
         {
           "word": "in",
@@ -2839,7 +3190,15 @@
           "word": "G?",
           "start": 150.62,
           "end": 150.8
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 150.92,
+      "end": 152.32,
+      "text": "And I can't forget by the N in the",
+      "words": [
         {
           "word": "And",
           "start": 150.92,
@@ -2889,10 +3248,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 41,
       "start": 152.32,
-      "end": 155.14,
-      "text": "G right now. N in the G. What do you get about",
+      "end": 153.04,
+      "text": "G right now.",
       "words": [
         {
           "word": "G",
@@ -2908,7 +3266,15 @@
           "word": "now.",
           "start": 152.72,
           "end": 153.04
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 153.6,
+      "end": 154.32,
+      "text": "N in the G.",
+      "words": [
         {
           "word": "N",
           "start": 153.6,
@@ -2928,7 +3294,15 @@
           "word": "G.",
           "start": 154.02,
           "end": 154.32
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 154.58,
+      "end": 155.14,
+      "text": "What do you get about",
+      "words": [
         {
           "word": "What",
           "start": 154.58,
@@ -2958,10 +3332,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 42,
       "start": 155.14,
-      "end": 157.36,
-      "text": "the N in the G? I got the power, the N in",
+      "end": 156.0,
+      "text": "the N in the G?",
       "words": [
         {
           "word": "the",
@@ -2987,7 +3360,15 @@
           "word": "G?",
           "start": 155.74,
           "end": 156.0
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 156.18,
+      "end": 157.36,
+      "text": "I got the power, the N in",
+      "words": [
         {
           "word": "I",
           "start": 156.18,
@@ -3027,10 +3408,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 43,
       "start": 157.36,
-      "end": 159.38,
-      "text": "the G to send them why they get send me to me.",
+      "end": 158.88,
+      "text": "the G to send them why they get send",
       "words": [
         {
           "word": "the",
@@ -3076,7 +3456,15 @@
           "word": "send",
           "start": 158.74,
           "end": 158.88
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 158.88,
+      "end": 159.38,
+      "text": "me to me.",
+      "words": [
         {
           "word": "me",
           "start": 158.88,
@@ -3096,10 +3484,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 44,
       "start": 159.46,
-      "end": 162.06,
-      "text": "Now none of them youths hate me, to me, they youths. They're",
+      "end": 161.1,
+      "text": "Now none of them youths hate me, to me,",
       "words": [
         {
           "word": "Now",
@@ -3145,7 +3532,15 @@
           "word": "me,",
           "start": 160.88,
           "end": 161.1
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 161.16,
+      "end": 162.06,
+      "text": "they youths. They're",
+      "words": [
         {
           "word": "they",
           "start": 161.16,
@@ -3165,10 +3560,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 45,
       "start": 162.06,
-      "end": 165.18,
-      "text": "not ready to me. They're not goons, they're men of fruits. They're",
+      "end": 162.84,
+      "text": "not ready to me.",
       "words": [
         {
           "word": "not",
@@ -3189,7 +3583,15 @@
           "word": "me.",
           "start": 162.6,
           "end": 162.84
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 163.12,
+      "end": 165.18,
+      "text": "They're not goons, they're men of fruits. They're",
+      "words": [
         {
           "word": "They're",
           "start": 163.12,
@@ -3234,10 +3636,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 46,
       "start": 165.18,
-      "end": 173.72,
-      "text": "little strawberries to me. Hey, ooh, save it. Go T .T. T",
+      "end": 166.34,
+      "text": "little strawberries to me.",
       "words": [
         {
           "word": "little",
@@ -3258,7 +3659,15 @@
           "word": "me.",
           "start": 166.08,
           "end": 166.34
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 168.16,
+      "end": 169.96,
+      "text": "Hey, ooh, save it.",
+      "words": [
         {
           "word": "Hey,",
           "start": 168.16,
@@ -3278,7 +3687,15 @@
           "word": "it.",
           "start": 169.72,
           "end": 169.96
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 172.34,
+      "end": 173.72,
+      "text": "Go T .T. T",
+      "words": [
         {
           "word": "Go",
           "start": 172.34,
@@ -3303,10 +3720,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 47,
       "start": 173.72,
-      "end": 180.64,
-      "text": ".T .T .T .T. What? T .T .T .T .T. Don't be",
+      "end": 177.64,
+      "text": ".T .T .T .T. What?",
       "words": [
         {
           "word": ".T",
@@ -3332,7 +3748,15 @@
           "word": "What?",
           "start": 177.04,
           "end": 177.64
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 179.0,
+      "end": 180.64,
+      "text": "T .T .T .T .T. Don't be",
+      "words": [
         {
           "word": "T",
           "start": 179.0,
@@ -3372,10 +3796,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 48,
       "start": 180.64,
-      "end": 184.94,
-      "text": "a peanut like a man. Fast 50 like a man. Hey, man,",
+      "end": 181.56,
+      "text": "a peanut like a man.",
       "words": [
         {
           "word": "a",
@@ -3401,7 +3824,15 @@
           "word": "man.",
           "start": 181.48,
           "end": 181.56
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 181.96,
+      "end": 184.94,
+      "text": "Fast 50 like a man. Hey, man,",
+      "words": [
         {
           "word": "Fast",
           "start": 181.96,
@@ -3441,10 +3872,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 49,
       "start": 185.02,
-      "end": 192.48,
-      "text": "don't be a peanut. Stop everything, my son. Too much, bro. T",
+      "end": 187.98,
+      "text": "don't be a peanut.",
       "words": [
         {
           "word": "don't",
@@ -3465,7 +3895,15 @@
           "word": "peanut.",
           "start": 187.68,
           "end": 187.98
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 188.3,
+      "end": 189.52,
+      "text": "Stop everything, my son.",
+      "words": [
         {
           "word": "Stop",
           "start": 188.3,
@@ -3485,7 +3923,15 @@
           "word": "son.",
           "start": 189.34,
           "end": 189.52
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 191.0,
+      "end": 192.82,
+      "text": "Too much, bro. T .T .T.",
+      "words": [
         {
           "word": "Too",
           "start": 191.0,
@@ -3505,16 +3951,7 @@
           "word": "T",
           "start": 192.34,
           "end": 192.48
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 50,
-      "start": 192.48,
-      "end": 198.94,
-      "text": ".T .T. This one skipped out. Pick up everybody that's locked. Oh,",
-      "words": [
+        },
         {
           "word": ".T",
           "start": 192.48,
@@ -3524,7 +3961,15 @@
           "word": ".T.",
           "start": 192.66,
           "end": 192.82
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 192.92,
+      "end": 194.08,
+      "text": "This one skipped out.",
+      "words": [
         {
           "word": "This",
           "start": 192.92,
@@ -3544,7 +3989,15 @@
           "word": "out.",
           "start": 193.48,
           "end": 194.08
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 195.08,
+      "end": 199.74,
+      "text": "Pick up everybody that's locked. Oh, my word.",
+      "words": [
         {
           "word": "Pick",
           "start": 195.08,
@@ -3574,16 +4027,7 @@
           "word": "Oh,",
           "start": 198.4,
           "end": 198.94
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 51,
-      "start": 199.02,
-      "end": 204.92,
-      "text": "my word. Oh, my word. Like M &M. Fast 50 like M",
-      "words": [
+        },
         {
           "word": "my",
           "start": 199.02,
@@ -3593,7 +4037,15 @@
           "word": "word.",
           "start": 199.18,
           "end": 199.74
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 201.28,
+      "end": 202.32,
+      "text": "Oh, my word.",
+      "words": [
         {
           "word": "Oh,",
           "start": 201.28,
@@ -3608,7 +4060,15 @@
           "word": "word.",
           "start": 202.32,
           "end": 202.32
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 202.32,
+      "end": 203.72,
+      "text": "Like M &M.",
+      "words": [
         {
           "word": "Like",
           "start": 202.32,
@@ -3623,7 +4083,15 @@
           "word": "&M.",
           "start": 203.22,
           "end": 203.72
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 203.8,
+      "end": 205.26,
+      "text": "Fast 50 like M &M.",
+      "words": [
         {
           "word": "Fast",
           "start": 203.8,
@@ -3643,21 +4111,20 @@
           "word": "M",
           "start": 204.74,
           "end": 204.92
+        },
+        {
+          "word": "&M.",
+          "start": 204.92,
+          "end": 205.26
         }
       ],
       "speaker": "D Double E"
     },
     {
-      "id": 52,
-      "start": 204.92,
-      "end": 209.14,
-      "text": "&M. Aim at them if you miss. Reload aim it again. Because",
+      "start": 205.26,
+      "end": 207.38,
+      "text": "Aim at them if you miss.",
       "words": [
-        {
-          "word": "&M.",
-          "start": 204.92,
-          "end": 205.26
-        },
         {
           "word": "Aim",
           "start": 205.26,
@@ -3687,7 +4154,15 @@
           "word": "miss.",
           "start": 207.14,
           "end": 207.38
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 207.62,
+      "end": 209.14,
+      "text": "Reload aim it again. Because",
+      "words": [
         {
           "word": "Reload",
           "start": 207.62,
@@ -3717,10 +4192,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 53,
       "start": 209.14,
-      "end": 212.22,
-      "text": "you know that the roads are bumpy. Just like a pump here",
+      "end": 210.46,
+      "text": "you know that the roads are bumpy.",
       "words": [
         {
           "word": "you",
@@ -3756,7 +4230,15 @@
           "word": "bumpy.",
           "start": 210.08,
           "end": 210.46
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 210.78,
+      "end": 212.22,
+      "text": "Just like a pump here",
+      "words": [
         {
           "word": "Just",
           "start": 210.78,
@@ -3786,10 +4268,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 54,
       "start": 212.22,
-      "end": 215.5,
-      "text": "like a glock 26. There's no safety. Listen for your own safety.",
+      "end": 212.92,
+      "text": "like a glock 26.",
       "words": [
         {
           "word": "like",
@@ -3810,7 +4291,15 @@
           "word": "26.",
           "start": 212.66,
           "end": 212.92
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 213.14,
+      "end": 213.9,
+      "text": "There's no safety.",
+      "words": [
         {
           "word": "There's",
           "start": 213.14,
@@ -3825,7 +4314,15 @@
           "word": "safety.",
           "start": 213.54,
           "end": 213.9
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 214.48,
+      "end": 215.5,
+      "text": "Listen for your own safety.",
+      "words": [
         {
           "word": "Listen",
           "start": 214.48,
@@ -3855,10 +4352,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 55,
       "start": 215.82,
-      "end": 218.92,
-      "text": "Don't be a peanut like M &M. Fast 50 like M &M.",
+      "end": 217.4,
+      "text": "Don't be a peanut like M &M.",
       "words": [
         {
           "word": "Don't",
@@ -3894,7 +4390,15 @@
           "word": "&M.",
           "start": 216.94,
           "end": 217.4
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 217.72,
+      "end": 218.92,
+      "text": "Fast 50 like M &M.",
+      "words": [
         {
           "word": "Fast",
           "start": 217.72,
@@ -3924,10 +4428,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 56,
       "start": 218.98,
-      "end": 223.02,
-      "text": "Aim at them if you miss. Reload aim it again. Because you",
+      "end": 221.12,
+      "text": "Aim at them if you miss.",
       "words": [
         {
           "word": "Aim",
@@ -3958,7 +4461,15 @@
           "word": "miss.",
           "start": 220.8,
           "end": 221.12
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 221.38,
+      "end": 223.02,
+      "text": "Reload aim it again. Because you",
+      "words": [
         {
           "word": "Reload",
           "start": 221.38,
@@ -3993,10 +4504,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 57,
       "start": 223.02,
-      "end": 226.08,
-      "text": "know that the roads are bumpy. Just like a pump here like",
+      "end": 224.2,
+      "text": "know that the roads are bumpy.",
       "words": [
         {
           "word": "know",
@@ -4027,7 +4537,15 @@
           "word": "bumpy.",
           "start": 223.8,
           "end": 224.2
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 224.52,
+      "end": 226.08,
+      "text": "Just like a pump here like",
+      "words": [
         {
           "word": "Just",
           "start": 224.52,
@@ -4062,10 +4580,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 58,
       "start": 226.08,
-      "end": 232.42000000000002,
-      "text": "a glock 26. There's no safety. Listen for your own safety. Too",
+      "end": 226.6,
+      "text": "a glock 26.",
       "words": [
         {
           "word": "a",
@@ -4081,7 +4598,15 @@
           "word": "26.",
           "start": 226.38,
           "end": 226.6
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 226.6,
+      "end": 227.6,
+      "text": "There's no safety.",
+      "words": [
         {
           "word": "There's",
           "start": 226.6,
@@ -4096,7 +4621,15 @@
           "word": "safety.",
           "start": 227.06,
           "end": 227.6
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 228.1,
+      "end": 232.42000000000002,
+      "text": "Listen for your own safety. Too",
+      "words": [
         {
           "word": "Listen",
           "start": 228.1,
@@ -4131,10 +4664,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 59,
       "start": 232.42000000000002,
-      "end": 236.88,
-      "text": "much. Rewind up. I don't care, Rewind boy. I'll slap guys. I",
+      "end": 234.54,
+      "text": "much. Rewind up.",
       "words": [
         {
           "word": "much.",
@@ -4150,7 +4682,15 @@
           "word": "up.",
           "start": 234.26,
           "end": 234.54
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 235.08,
+      "end": 236.0,
+      "text": "I don't care, Rewind boy.",
+      "words": [
         {
           "word": "I",
           "start": 235.08,
@@ -4175,7 +4715,15 @@
           "word": "boy.",
           "start": 235.78,
           "end": 236.0
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 236.08,
+      "end": 236.88,
+      "text": "I'll slap guys. I",
+      "words": [
         {
           "word": "I'll",
           "start": 236.08,
@@ -4200,10 +4748,9 @@
       "speaker": "JME"
     },
     {
-      "id": 60,
       "start": 236.88,
-      "end": 242.54,
-      "text": "don't care, Rewind boy. I don't care, Rewind boy. Hey, that's the",
+      "end": 237.72,
+      "text": "don't care, Rewind boy.",
       "words": [
         {
           "word": "don't",
@@ -4224,7 +4771,15 @@
           "word": "boy.",
           "start": 237.54,
           "end": 237.72
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 237.86,
+      "end": 239.38,
+      "text": "I don't care, Rewind boy.",
+      "words": [
         {
           "word": "I",
           "start": 237.86,
@@ -4249,7 +4804,15 @@
           "word": "boy.",
           "start": 239.24,
           "end": 239.38
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 241.26,
+      "end": 242.54,
+      "text": "Hey, that's the",
+      "words": [
         {
           "word": "Hey,",
           "start": 241.26,
@@ -4269,10 +4832,9 @@
       "speaker": "JME"
     },
     {
-      "id": 61,
       "start": 242.54,
-      "end": 245.48,
-      "text": "moj, I swear. When I'm driving, that's all I say, bro. I",
+      "end": 243.04,
+      "text": "moj, I swear.",
       "words": [
         {
           "word": "moj,",
@@ -4288,7 +4850,15 @@
           "word": "swear.",
           "start": 242.88,
           "end": 243.04
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 243.4,
+      "end": 245.48,
+      "text": "When I'm driving, that's all I say, bro. I",
+      "words": [
         {
           "word": "When",
           "start": 243.4,
@@ -4338,10 +4908,9 @@
       "speaker": "JME"
     },
     {
-      "id": 62,
       "start": 245.48,
-      "end": 247.98,
-      "text": "don't care, Rewind boy. I'll slap guys. I don't care, Rewind boy.",
+      "end": 246.26,
+      "text": "don't care, Rewind boy.",
       "words": [
         {
           "word": "don't",
@@ -4362,7 +4931,15 @@
           "word": "boy.",
           "start": 246.08,
           "end": 246.26
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 246.38,
+      "end": 246.98,
+      "text": "I'll slap guys.",
+      "words": [
         {
           "word": "I'll",
           "start": 246.38,
@@ -4377,7 +4954,15 @@
           "word": "guys.",
           "start": 246.64,
           "end": 246.98
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 247.14,
+      "end": 247.98,
+      "text": "I don't care, Rewind boy.",
+      "words": [
         {
           "word": "I",
           "start": 247.14,
@@ -4407,10 +4992,9 @@
       "speaker": "JME"
     },
     {
-      "id": 63,
       "start": 248.16,
-      "end": 250.62,
-      "text": "I'll slap guys. I don't care, Rewind boy. I'll slap guys. I",
+      "end": 248.7,
+      "text": "I'll slap guys.",
       "words": [
         {
           "word": "I'll",
@@ -4426,7 +5010,15 @@
           "word": "guys.",
           "start": 248.38,
           "end": 248.7
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 248.7,
+      "end": 249.84,
+      "text": "I don't care, Rewind boy.",
+      "words": [
         {
           "word": "I",
           "start": 248.7,
@@ -4451,7 +5043,15 @@
           "word": "boy.",
           "start": 249.66,
           "end": 249.84
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 249.84,
+      "end": 250.62,
+      "text": "I'll slap guys. I",
+      "words": [
         {
           "word": "I'll",
           "start": 249.84,
@@ -4476,10 +5076,9 @@
       "speaker": "JME"
     },
     {
-      "id": 64,
       "start": 250.62,
-      "end": 257.44,
-      "text": "don't care, Rewind boy. Alright, big up teaser. Look in my bow,",
+      "end": 251.4,
+      "text": "don't care, Rewind boy.",
       "words": [
         {
           "word": "don't",
@@ -4500,7 +5099,15 @@
           "word": "boy.",
           "start": 251.22,
           "end": 251.4
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 253.72000000000003,
+      "end": 254.84,
+      "text": "Alright, big up teaser.",
+      "words": [
         {
           "word": "Alright,",
           "start": 253.72000000000003,
@@ -4520,7 +5127,15 @@
           "word": "teaser.",
           "start": 254.56,
           "end": 254.84
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 256.64,
+      "end": 257.88,
+      "text": "Look in my bow, fine.",
+      "words": [
         {
           "word": "Look",
           "start": 256.64,
@@ -4540,21 +5155,20 @@
           "word": "bow,",
           "start": 257.3,
           "end": 257.44
+        },
+        {
+          "word": "fine.",
+          "start": 257.66,
+          "end": 257.88
         }
       ],
       "speaker": "JME"
     },
     {
-      "id": 65,
-      "start": 257.66,
-      "end": 260.5,
-      "text": "fine. You're the reason I rode this rhyme. Yo man, I bait",
+      "start": 258.16,
+      "end": 259.6,
+      "text": "You're the reason I rode this rhyme.",
       "words": [
-        {
-          "word": "fine.",
-          "start": 257.66,
-          "end": 257.88
-        },
         {
           "word": "You're",
           "start": 258.16,
@@ -4589,7 +5203,15 @@
           "word": "rhyme.",
           "start": 259.4,
           "end": 259.6
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 259.9,
+      "end": 260.82,
+      "text": "Yo man, I bait as man.",
+      "words": [
         {
           "word": "Yo",
           "start": 259.9,
@@ -4609,16 +5231,7 @@
           "word": "bait",
           "start": 260.32,
           "end": 260.5
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 66,
-      "start": 260.5,
-      "end": 262.38,
-      "text": "as man. I've had man, man, I ain't seen a fight. I",
-      "words": [
+        },
         {
           "word": "as",
           "start": 260.5,
@@ -4628,7 +5241,15 @@
           "word": "man.",
           "start": 260.66,
           "end": 260.82
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 260.9,
+      "end": 262.18,
+      "text": "I've had man, man, I ain't seen a fight.",
+      "words": [
         {
           "word": "I've",
           "start": 260.9,
@@ -4673,21 +5294,20 @@
           "word": "fight.",
           "start": 262.0,
           "end": 262.18
-        },
-        {
-          "word": "I",
-          "start": 262.38,
-          "end": 262.38
         }
       ],
       "speaker": "JME"
     },
     {
-      "id": 67,
       "start": 262.38,
-      "end": 265.64,
-      "text": "know in time. Yo, can't disappoint of mine. Trust me, you don't",
+      "end": 263.02,
+      "text": "I know in time.",
       "words": [
+        {
+          "word": "I",
+          "start": 262.38,
+          "end": 262.38
+        },
         {
           "word": "know",
           "start": 262.38,
@@ -4702,7 +5322,15 @@
           "word": "time.",
           "start": 262.76,
           "end": 263.02
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 263.32,
+      "end": 264.72,
+      "text": "Yo, can't disappoint of mine.",
+      "words": [
         {
           "word": "Yo,",
           "start": 263.32,
@@ -4727,7 +5355,15 @@
           "word": "mine.",
           "start": 264.48,
           "end": 264.72
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 264.96,
+      "end": 265.64,
+      "text": "Trust me, you don't",
+      "words": [
         {
           "word": "Trust",
           "start": 264.96,
@@ -4752,10 +5388,9 @@
       "speaker": "JME"
     },
     {
-      "id": 68,
       "start": 265.64,
-      "end": 268.02,
-      "text": "wanna cross this line. Don't think you can stand in the background",
+      "end": 266.46,
+      "text": "wanna cross this line.",
       "words": [
         {
           "word": "wanna",
@@ -4776,7 +5411,15 @@
           "word": "line.",
           "start": 266.22,
           "end": 266.46
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 266.72,
+      "end": 268.02,
+      "text": "Don't think you can stand in the background",
+      "words": [
         {
           "word": "Don't",
           "start": 266.72,
@@ -4821,10 +5464,9 @@
       "speaker": "JME"
     },
     {
-      "id": 69,
       "start": 268.02,
-      "end": 271.12,
-      "text": "to the video ad libbing X -Men's rhyme. Slap, do you think",
+      "end": 269.84,
+      "text": "to the video ad libbing X -Men's rhyme.",
       "words": [
         {
           "word": "to",
@@ -4865,7 +5507,15 @@
           "word": "rhyme.",
           "start": 269.7,
           "end": 269.84
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 270.22,
+      "end": 271.54,
+      "text": "Slap, do you think I'm dumb?",
+      "words": [
         {
           "word": "Slap,",
           "start": 270.22,
@@ -4885,16 +5535,7 @@
           "word": "think",
           "start": 270.98,
           "end": 271.12
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 70,
-      "start": 271.12,
-      "end": 273.94,
-      "text": "I'm dumb? Try to boy me, nah, that can't run. Yo, you",
-      "words": [
+        },
         {
           "word": "I'm",
           "start": 271.12,
@@ -4904,7 +5545,15 @@
           "word": "dumb?",
           "start": 271.4,
           "end": 271.54
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 271.84,
+      "end": 273.26,
+      "text": "Try to boy me, nah, that can't run.",
+      "words": [
         {
           "word": "Try",
           "start": 271.84,
@@ -4944,7 +5593,15 @@
           "word": "run.",
           "start": 273.1,
           "end": 273.26
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 273.26,
+      "end": 275.0,
+      "text": "Yo, you lucky, the old jammy.",
+      "words": [
         {
           "word": "Yo,",
           "start": 273.26,
@@ -4954,16 +5611,7 @@
           "word": "you",
           "start": 273.72,
           "end": 273.94
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 71,
-      "start": 273.94,
-      "end": 277.06,
-      "text": "lucky, the old jammy. But I am just like Jamaican rum. Cos",
-      "words": [
+        },
         {
           "word": "lucky,",
           "start": 273.94,
@@ -4983,7 +5631,15 @@
           "word": "jammy.",
           "start": 274.6,
           "end": 275.0
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 275.14,
+      "end": 277.06,
+      "text": "But I am just like Jamaican rum. Cos",
+      "words": [
         {
           "word": "But",
           "start": 275.14,
@@ -5028,10 +5684,9 @@
       "speaker": "JME"
     },
     {
-      "id": 72,
       "start": 277.06,
-      "end": 278.98,
-      "text": "you got a name in your night care dumps. Cos you got",
+      "end": 278.6,
+      "text": "you got a name in your night care dumps.",
       "words": [
         {
           "word": "you",
@@ -5077,7 +5732,15 @@
           "word": "dumps.",
           "start": 278.2,
           "end": 278.6
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 278.62,
+      "end": 278.98,
+      "text": "Cos you got",
+      "words": [
         {
           "word": "Cos",
           "start": 278.62,
@@ -5097,10 +5760,9 @@
       "speaker": "JME"
     },
     {
-      "id": 73,
       "start": 278.98,
-      "end": 281.0,
-      "text": "a name in your Air Force once. You could have a name",
+      "end": 280.12,
+      "text": "a name in your Air Force once.",
       "words": [
         {
           "word": "a",
@@ -5136,7 +5798,15 @@
           "word": "once.",
           "start": 279.88,
           "end": 280.12
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 280.44,
+      "end": 281.0,
+      "text": "You could have a name",
+      "words": [
         {
           "word": "You",
           "start": 280.44,
@@ -5166,10 +5836,9 @@
       "speaker": "JME"
     },
     {
-      "id": 74,
       "start": 281.0,
-      "end": 284.4,
-      "text": "in your Re -Whip pumps. No victim could ever disman once. Serious.",
+      "end": 281.88,
+      "text": "in your Re -Whip pumps.",
       "words": [
         {
           "word": "in",
@@ -5195,7 +5864,15 @@
           "word": "pumps.",
           "start": 281.6,
           "end": 281.88
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 282.16,
+      "end": 284.4,
+      "text": "No victim could ever disman once. Serious.",
+      "words": [
         {
           "word": "No",
           "start": 282.16,
@@ -5235,10 +5912,9 @@
       "speaker": "JME"
     },
     {
-      "id": 75,
       "start": 286.82,
-      "end": 292.62,
-      "text": "Yo, party. Look, it's going in. It is not the Nola mixing.",
+      "end": 290.28,
+      "text": "Yo, party. Look, it's going in.",
       "words": [
         {
           "word": "Yo,",
@@ -5269,7 +5945,15 @@
           "word": "in.",
           "start": 289.92,
           "end": 290.28
-        },
+        }
+      ],
+      "speaker": "unknown"
+    },
+    {
+      "start": 290.96,
+      "end": 292.62,
+      "text": "It is not the Nola mixing.",
+      "words": [
         {
           "word": "It",
           "start": 290.96,
@@ -5304,10 +5988,9 @@
       "speaker": "unknown"
     },
     {
-      "id": 76,
       "start": 292.94,
-      "end": 300.02,
-      "text": "Ha ha ha. Hey, hey, hey, hey, hey. Look, layman down. Don't",
+      "end": 294.38,
+      "text": "Ha ha ha.",
       "words": [
         {
           "word": "Ha",
@@ -5323,7 +6006,15 @@
           "word": "ha.",
           "start": 293.94,
           "end": 294.38
-        },
+        }
+      ],
+      "speaker": "SPEAKER_06"
+    },
+    {
+      "start": 294.82,
+      "end": 296.1,
+      "text": "Hey, hey, hey, hey, hey.",
+      "words": [
         {
           "word": "Hey,",
           "start": 294.82,
@@ -5348,7 +6039,15 @@
           "word": "hey.",
           "start": 295.76,
           "end": 296.1
-        },
+        }
+      ],
+      "speaker": "SPEAKER_06"
+    },
+    {
+      "start": 296.1,
+      "end": 300.02,
+      "text": "Look, layman down. Don't",
+      "words": [
         {
           "word": "Look,",
           "start": 296.1,
@@ -5373,10 +6072,9 @@
       "speaker": "SPEAKER_06"
     },
     {
-      "id": 77,
       "start": 300.02,
-      "end": 302.68,
-      "text": "think I won't layman down. Last break came to the war with",
+      "end": 301.22,
+      "text": "think I won't layman down.",
       "words": [
         {
           "word": "think",
@@ -5402,7 +6100,15 @@
           "word": "down.",
           "start": 300.9,
           "end": 301.22
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 301.22,
+      "end": 302.68,
+      "text": "Last break came to the war with",
+      "words": [
         {
           "word": "Last",
           "start": 301.22,
@@ -5442,10 +6148,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 78,
       "start": 302.68,
-      "end": 305.5,
-      "text": "20 men and left the war like 10 men down. The other",
+      "end": 304.32,
+      "text": "20 men and left the war like 10 men",
       "words": [
         {
           "word": "20",
@@ -5491,7 +6196,15 @@
           "word": "men",
           "start": 304.14,
           "end": 304.32
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 304.32,
+      "end": 305.5,
+      "text": "down. The other",
+      "words": [
         {
           "word": "down.",
           "start": 304.32,
@@ -5511,10 +6224,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 79,
       "start": 305.5,
-      "end": 308.7,
-      "text": "teams did get hit. Then I keep ass justin' and die. Don't",
+      "end": 306.38,
+      "text": "teams did get hit.",
       "words": [
         {
           "word": "teams",
@@ -5535,7 +6247,15 @@
           "word": "hit.",
           "start": 306.08,
           "end": 306.38
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 306.7,
+      "end": 308.7,
+      "text": "Then I keep ass justin' and die. Don't",
+      "words": [
         {
           "word": "Then",
           "start": 306.7,
@@ -5580,10 +6300,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 80,
       "start": 308.7,
-      "end": 310.8,
-      "text": "think man, I off with the aim. Confuse, fussy man, I'll be",
+      "end": 309.7,
+      "text": "think man, I off with the aim.",
       "words": [
         {
           "word": "think",
@@ -5619,7 +6338,15 @@
           "word": "aim.",
           "start": 309.54,
           "end": 309.7
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 309.8,
+      "end": 310.8,
+      "text": "Confuse, fussy man, I'll be",
+      "words": [
         {
           "word": "Confuse,",
           "start": 309.8,
@@ -5649,10 +6376,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 81,
       "start": 310.8,
-      "end": 312.82,
-      "text": "off with your chain and I couldn't give a f about what's",
+      "end": 312.1,
+      "text": "off with your chain and I couldn't give a",
       "words": [
         {
           "word": "off",
@@ -5698,7 +6424,15 @@
           "word": "a",
           "start": 312.02,
           "end": 312.1
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 312.1,
+      "end": 313.24,
+      "text": "f about what's his name.",
+      "words": [
         {
           "word": "f",
           "start": 312.1,
@@ -5713,16 +6447,7 @@
           "word": "what's",
           "start": 312.44,
           "end": 312.82
-        }
-      ],
-      "speaker": "Footsie"
-    },
-    {
-      "id": 82,
-      "start": 312.82,
-      "end": 315.58,
-      "text": "his name. All about what's his face. Man, I'm hitting with a",
-      "words": [
+        },
         {
           "word": "his",
           "start": 312.82,
@@ -5732,7 +6457,15 @@
           "word": "name.",
           "start": 312.92,
           "end": 313.24
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 313.78,
+      "end": 314.82,
+      "text": "All about what's his face.",
+      "words": [
         {
           "word": "All",
           "start": 313.78,
@@ -5757,7 +6490,15 @@
           "word": "face.",
           "start": 314.64,
           "end": 314.82
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 314.96,
+      "end": 315.58,
+      "text": "Man, I'm hitting with a",
+      "words": [
         {
           "word": "Man,",
           "start": 314.96,
@@ -5787,10 +6528,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 83,
       "start": 315.58,
-      "end": 317.28,
-      "text": "sin and I watch his face and I make up what I",
+      "end": 316.94,
+      "text": "sin and I watch his face and I make",
       "words": [
         {
           "word": "sin",
@@ -5836,7 +6576,15 @@
           "word": "make",
           "start": 316.8,
           "end": 316.94
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 316.94,
+      "end": 317.5,
+      "text": "up what I know.",
+      "words": [
         {
           "word": "up",
           "start": 316.94,
@@ -5851,21 +6599,20 @@
           "word": "I",
           "start": 317.22,
           "end": 317.28
+        },
+        {
+          "word": "know.",
+          "start": 317.28,
+          "end": 317.5
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 84,
-      "start": 317.28,
-      "end": 320.08,
-      "text": "know. What's his face? He don't believe me. Just watch his face.",
+      "start": 317.82,
+      "end": 318.32,
+      "text": "What's his face?",
       "words": [
-        {
-          "word": "know.",
-          "start": 317.28,
-          "end": 317.5
-        },
         {
           "word": "What's",
           "start": 317.82,
@@ -5880,7 +6627,15 @@
           "word": "face?",
           "start": 318.12,
           "end": 318.32
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 318.44,
+      "end": 319.16,
+      "text": "He don't believe me.",
+      "words": [
         {
           "word": "He",
           "start": 318.44,
@@ -5900,7 +6655,15 @@
           "word": "me.",
           "start": 318.92,
           "end": 319.16
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 319.32,
+      "end": 320.08,
+      "text": "Just watch his face.",
+      "words": [
         {
           "word": "Just",
           "start": 319.32,
@@ -5925,10 +6688,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 85,
       "start": 320.34,
-      "end": 322.64,
-      "text": "Man, I bad man, no watch, no face. I got a four,",
+      "end": 321.8,
+      "text": "Man, I bad man, no watch, no face.",
       "words": [
         {
           "word": "Man,",
@@ -5969,7 +6731,15 @@
           "word": "face.",
           "start": 321.46,
           "end": 321.8
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 322.22,
+      "end": 322.64,
+      "text": "I got a four,",
+      "words": [
         {
           "word": "I",
           "start": 322.22,
@@ -5994,10 +6764,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 86,
       "start": 322.72,
-      "end": 325.48,
-      "text": "five and I'm a juicy twain. Don't get lucky in my face.",
+      "end": 323.96,
+      "text": "five and I'm a juicy twain.",
       "words": [
         {
           "word": "five",
@@ -6028,7 +6797,15 @@
           "word": "twain.",
           "start": 323.5,
           "end": 323.96
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 323.96,
+      "end": 325.48,
+      "text": "Don't get lucky in my face.",
+      "words": [
         {
           "word": "Don't",
           "start": 323.96,
@@ -6063,10 +6840,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 87,
       "start": 325.96,
-      "end": 331.2,
-      "text": "Ha ha ha. That one's a party. That, that, that, that, that.",
+      "end": 326.78,
+      "text": "Ha ha ha.",
       "words": [
         {
           "word": "Ha",
@@ -6082,7 +6858,15 @@
           "word": "ha.",
           "start": 326.66,
           "end": 326.78
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 327.82,
+      "end": 328.98,
+      "text": "That one's a party.",
+      "words": [
         {
           "word": "That",
           "start": 327.82,
@@ -6102,7 +6886,15 @@
           "word": "party.",
           "start": 328.64,
           "end": 328.98
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 329.8,
+      "end": 331.2,
+      "text": "That, that, that, that, that.",
+      "words": [
         {
           "word": "That,",
           "start": 329.8,
@@ -6132,10 +6924,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 88,
       "start": 331.28,
-      "end": 335.54,
-      "text": "I got a four, five and I'm a juicy twain. Yo, what",
+      "end": 332.9,
+      "text": "I got a four, five and I'm a juicy",
       "words": [
         {
           "word": "I",
@@ -6181,7 +6972,15 @@
           "word": "juicy",
           "start": 332.7,
           "end": 332.9
-        },
+        }
+      ],
+      "speaker": "unknown"
+    },
+    {
+      "start": 332.9,
+      "end": 335.54,
+      "text": "twain. Yo, what",
+      "words": [
         {
           "word": "twain.",
           "start": 332.9,
@@ -6201,10 +7000,9 @@
       "speaker": "unknown"
     },
     {
-      "id": 89,
       "start": 335.54,
-      "end": 341.48,
-      "text": "me sing? I've been doing this thing from early. I've been doing",
+      "end": 340.8,
+      "text": "me sing? I've been doing this thing from early.",
       "words": [
         {
           "word": "me",
@@ -6250,7 +7048,15 @@
           "word": "early.",
           "start": 340.36,
           "end": 340.8
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 341.16,
+      "end": 341.48,
+      "text": "I've been doing",
+      "words": [
         {
           "word": "I've",
           "start": 341.16,
@@ -6270,10 +7076,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 90,
       "start": 341.48,
-      "end": 344.58,
-      "text": "this thing from day. Don't believe me, you cannot choke early. She",
+      "end": 342.38,
+      "text": "this thing from day.",
       "words": [
         {
           "word": "this",
@@ -6294,7 +7099,15 @@
           "word": "day.",
           "start": 342.06,
           "end": 342.38
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 342.7,
+      "end": 344.58,
+      "text": "Don't believe me, you cannot choke early. She",
+      "words": [
         {
           "word": "Don't",
           "start": 342.7,
@@ -6339,10 +7152,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 91,
       "start": 344.58,
-      "end": 347.3,
-      "text": "be listenin' to me from day. She got a shoebox in her",
+      "end": 345.84,
+      "text": "be listenin' to me from day.",
       "words": [
         {
           "word": "be",
@@ -6373,7 +7185,15 @@
           "word": "day.",
           "start": 345.5,
           "end": 345.84
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 346.16,
+      "end": 347.3,
+      "text": "She got a shoebox in her",
+      "words": [
         {
           "word": "She",
           "start": 346.16,
@@ -6408,10 +7228,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 92,
       "start": 347.3,
-      "end": 350.22,
-      "text": "bedroom and it's full of fatigue, decay, but the beddie double from",
+      "end": 349.46,
+      "text": "bedroom and it's full of fatigue, decay, but the",
       "words": [
         {
           "word": "bedroom",
@@ -6457,7 +7276,15 @@
           "word": "the",
           "start": 349.34,
           "end": 349.46
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 349.46,
+      "end": 350.22,
+      "text": "beddie double from",
+      "words": [
         {
           "word": "beddie",
           "start": 349.46,
@@ -6477,10 +7304,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 93,
       "start": 350.22,
-      "end": 353.82,
-      "text": "back and the beddie double from back and the day. I make",
+      "end": 352.54,
+      "text": "back and the beddie double from back and the",
       "words": [
         {
           "word": "back",
@@ -6526,7 +7352,15 @@
           "word": "the",
           "start": 352.42,
           "end": 352.54
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 352.54,
+      "end": 353.82,
+      "text": "day. I make",
+      "words": [
         {
           "word": "day.",
           "start": 352.54,
@@ -6546,10 +7380,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 94,
       "start": 353.82,
-      "end": 356.44,
-      "text": "it say cool, fly me. That voice got wicked style, he wants",
+      "end": 354.74,
+      "text": "it say cool, fly me.",
       "words": [
         {
           "word": "it",
@@ -6575,7 +7408,15 @@
           "word": "me.",
           "start": 354.58,
           "end": 354.74
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 354.9,
+      "end": 356.98,
+      "text": "That voice got wicked style, he wants his name.",
+      "words": [
         {
           "word": "That",
           "start": 354.9,
@@ -6610,16 +7451,7 @@
           "word": "wants",
           "start": 356.26,
           "end": 356.44
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 95,
-      "start": 356.44,
-      "end": 359.72,
-      "text": "his name. D -double E, best in treating the industry. When I",
-      "words": [
+        },
         {
           "word": "his",
           "start": 356.44,
@@ -6629,7 +7461,15 @@
           "word": "name.",
           "start": 356.66,
           "end": 356.98
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 357.24,
+      "end": 358.9,
+      "text": "D -double E, best in treating the",
+      "words": [
         {
           "word": "D",
           "start": 357.24,
@@ -6664,7 +7504,15 @@
           "word": "the",
           "start": 358.66,
           "end": 358.9
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 358.9,
+      "end": 359.72,
+      "text": "industry. When I",
+      "words": [
         {
           "word": "industry.",
           "start": 358.9,
@@ -6684,10 +7532,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 96,
       "start": 359.72,
-      "end": 362.06,
-      "text": "chop up on the mic, I make it say cool. That voice",
+      "end": 360.92,
+      "text": "chop up on the mic, I make it say",
       "words": [
         {
           "word": "chop",
@@ -6733,7 +7580,15 @@
           "word": "say",
           "start": 360.8,
           "end": 360.92
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 360.92,
+      "end": 362.06,
+      "text": "cool. That voice",
+      "words": [
         {
           "word": "cool.",
           "start": 360.92,
@@ -6753,10 +7608,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 97,
       "start": 362.06,
-      "end": 365.44,
-      "text": "got lyrics cool. He's supported Dizzy on tour. Has got a mix",
+      "end": 362.76,
+      "text": "got lyrics cool.",
       "words": [
         {
           "word": "got",
@@ -6772,7 +7626,15 @@
           "word": "cool.",
           "start": 362.44,
           "end": 362.76
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 363.2,
+      "end": 364.64,
+      "text": "He's supported Dizzy on tour.",
+      "words": [
         {
           "word": "He's",
           "start": 363.2,
@@ -6797,7 +7659,15 @@
           "word": "tour.",
           "start": 364.38,
           "end": 364.64
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 364.94,
+      "end": 365.44,
+      "text": "Has got a mix",
+      "words": [
         {
           "word": "Has",
           "start": 364.94,
@@ -6822,10 +7692,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 98,
       "start": 365.44,
-      "end": 370.3,
-      "text": "up and want to hear more. What's going on in fam? Bare",
+      "end": 366.4,
+      "text": "up and want to hear more.",
       "words": [
         {
           "word": "up",
@@ -6856,7 +7725,15 @@
           "word": "more.",
           "start": 366.04,
           "end": 366.4
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 368.78,
+      "end": 370.3,
+      "text": "What's going on in fam? Bare",
+      "words": [
         {
           "word": "What's",
           "start": 368.78,
@@ -6891,10 +7768,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 99,
       "start": 370.3,
-      "end": 372.72,
-      "text": "wraps, cats trying to bite me like I put my whole arm",
+      "end": 372.12,
+      "text": "wraps, cats trying to bite me like I put",
       "words": [
         {
           "word": "wraps,",
@@ -6940,7 +7816,15 @@
           "word": "put",
           "start": 372.06,
           "end": 372.12
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 372.12,
+      "end": 373.12,
+      "text": "my whole arm in jam.",
+      "words": [
         {
           "word": "my",
           "start": 372.12,
@@ -6955,16 +7839,7 @@
           "word": "arm",
           "start": 372.46,
           "end": 372.72
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 100,
-      "start": 372.72,
-      "end": 375.56,
-      "text": "in jam. Step out of the whip, fill up the tank. Boss",
-      "words": [
+        },
         {
           "word": "in",
           "start": 372.72,
@@ -6974,7 +7849,15 @@
           "word": "jam.",
           "start": 372.9,
           "end": 373.12
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 373.38,
+      "end": 374.96,
+      "text": "Step out of the whip, fill up the tank.",
+      "words": [
         {
           "word": "Step",
           "start": 373.38,
@@ -7019,21 +7902,20 @@
           "word": "tank.",
           "start": 374.64,
           "end": 374.96
-        },
-        {
-          "word": "Boss",
-          "start": 375.36,
-          "end": 375.56
         }
       ],
       "speaker": "JME"
     },
     {
-      "id": 101,
-      "start": 375.56,
-      "end": 379.62,
-      "text": "mic, fill up my bank. Mom's life, damn man. I keep my",
+      "start": 375.36,
+      "end": 376.62,
+      "text": "Boss mic, fill up my bank.",
       "words": [
+        {
+          "word": "Boss",
+          "start": 375.36,
+          "end": 375.56
+        },
         {
           "word": "mic,",
           "start": 375.56,
@@ -7058,7 +7940,15 @@
           "word": "bank.",
           "start": 376.36,
           "end": 376.62
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 377.02,
+      "end": 378.06,
+      "text": "Mom's life, damn man.",
+      "words": [
         {
           "word": "Mom's",
           "start": 377.02,
@@ -7078,7 +7968,15 @@
           "word": "man.",
           "start": 377.84,
           "end": 378.06
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 378.92,
+      "end": 379.62,
+      "text": "I keep my",
+      "words": [
         {
           "word": "I",
           "start": 378.92,
@@ -7098,10 +7996,9 @@
       "speaker": "JME"
     },
     {
-      "id": 102,
       "start": 379.62,
-      "end": 382.16,
-      "text": "hands dirty on the other hand. I keep my hands clean, you",
+      "end": 380.86,
+      "text": "hands dirty on the other hand.",
       "words": [
         {
           "word": "hands",
@@ -7132,7 +8029,15 @@
           "word": "hand.",
           "start": 380.58,
           "end": 380.86
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 380.86,
+      "end": 382.78,
+      "text": "I keep my hands clean, you get murked.",
+      "words": [
         {
           "word": "I",
           "start": 380.86,
@@ -7162,16 +8067,7 @@
           "word": "you",
           "start": 381.92,
           "end": 382.16
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 103,
-      "start": 382.16,
-      "end": 386.32,
-      "text": "get murked. Hands free, Bluetooth, Wi -Fi. I speak the truth at",
-      "words": [
+        },
         {
           "word": "get",
           "start": 382.16,
@@ -7181,7 +8077,15 @@
           "word": "murked.",
           "start": 382.32,
           "end": 382.78
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 382.86,
+      "end": 385.22,
+      "text": "Hands free, Bluetooth, Wi -Fi.",
+      "words": [
         {
           "word": "Hands",
           "start": 382.86,
@@ -7206,7 +8110,15 @@
           "word": "-Fi.",
           "start": 384.94,
           "end": 385.22
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 385.46,
+      "end": 386.32,
+      "text": "I speak the truth at",
+      "words": [
         {
           "word": "I",
           "start": 385.46,
@@ -7236,10 +8148,9 @@
       "speaker": "JME"
     },
     {
-      "id": 104,
       "start": 386.32,
-      "end": 388.92,
-      "text": "your hi -fi. When I'm on the mic, headphones don't lie. I",
+      "end": 386.78,
+      "text": "your hi -fi.",
       "words": [
         {
           "word": "your",
@@ -7255,7 +8166,15 @@
           "word": "-fi.",
           "start": 386.6,
           "end": 386.78
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 387.1,
+      "end": 388.92,
+      "text": "When I'm on the mic, headphones don't lie. I",
+      "words": [
         {
           "word": "When",
           "start": 387.1,
@@ -7305,10 +8224,9 @@
       "speaker": "JME"
     },
     {
-      "id": 105,
       "start": 388.92,
-      "end": 392.98,
-      "text": "take your sh -ini, meanie, mine. Nemo, yeah, you can't find. Reload,",
+      "end": 390.32,
+      "text": "take your sh -ini, meanie, mine.",
       "words": [
         {
           "word": "take",
@@ -7339,7 +8257,15 @@
           "word": "mine.",
           "start": 390.2,
           "end": 390.32
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 390.8,
+      "end": 392.98,
+      "text": "Nemo, yeah, you can't find. Reload,",
+      "words": [
         {
           "word": "Nemo,",
           "start": 390.8,
@@ -7374,10 +8300,9 @@
       "speaker": "JME"
     },
     {
-      "id": 106,
       "start": 393.04,
-      "end": 399.96,
-      "text": "yeah, the bars, cram. Padding them, if... Easy, easy, easy. Let me",
+      "end": 393.96,
+      "text": "yeah, the bars, cram.",
       "words": [
         {
           "word": "yeah,",
@@ -7398,7 +8323,15 @@
           "word": "cram.",
           "start": 393.58,
           "end": 393.96
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 394.9,
+      "end": 396.92,
+      "text": "Padding them, if...",
+      "words": [
         {
           "word": "Padding",
           "start": 394.9,
@@ -7413,7 +8346,15 @@
           "word": "if...",
           "start": 395.9,
           "end": 396.92
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 396.92,
+      "end": 399.96,
+      "text": "Easy, easy, easy. Let me",
+      "words": [
         {
           "word": "Easy,",
           "start": 396.92,
@@ -7443,10 +8384,9 @@
       "speaker": "JME"
     },
     {
-      "id": 107,
       "start": 399.96,
-      "end": 403.3,
-      "text": "come back again. Ween, let me come back again. Everybody knows that",
+      "end": 400.64,
+      "text": "come back again.",
       "words": [
         {
           "word": "come",
@@ -7462,7 +8402,15 @@
           "word": "again.",
           "start": 400.26,
           "end": 400.64
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 401.06,
+      "end": 402.38,
+      "text": "Ween, let me come back again.",
+      "words": [
         {
           "word": "Ween,",
           "start": 401.06,
@@ -7492,7 +8440,15 @@
           "word": "again.",
           "start": 402.02,
           "end": 402.38
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 402.66,
+      "end": 403.3,
+      "text": "Everybody knows that",
+      "words": [
         {
           "word": "Everybody",
           "start": 402.66,
@@ -7512,10 +8468,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 108,
       "start": 403.3,
-      "end": 405.72,
-      "text": "we're better than, better than look. Ween, let me come back again.",
+      "end": 404.44,
+      "text": "we're better than, better than look.",
       "words": [
         {
           "word": "we're",
@@ -7546,7 +8501,15 @@
           "word": "look.",
           "start": 404.28,
           "end": 404.44
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 404.68,
+      "end": 405.72,
+      "text": "Ween, let me come back again.",
+      "words": [
         {
           "word": "Ween,",
           "start": 404.68,
@@ -7581,10 +8544,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 109,
       "start": 406.02,
-      "end": 409.0,
-      "text": "Everybody knows that we're better than look, look, look. We're better than",
+      "end": 407.84,
+      "text": "Everybody knows that we're better than look, look, look.",
       "words": [
         {
           "word": "Everybody",
@@ -7630,7 +8592,15 @@
           "word": "look.",
           "start": 407.76,
           "end": 407.84
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 407.84,
+      "end": 409.0,
+      "text": "We're better than",
+      "words": [
         {
           "word": "We're",
           "start": 407.84,
@@ -7650,10 +8620,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 110,
       "start": 409.0,
-      "end": 412.26,
-      "text": "them, bad wifey. Oh, now, bad wifey them. They've got bars, we've",
+      "end": 409.88,
+      "text": "them, bad wifey.",
       "words": [
         {
           "word": "them,",
@@ -7669,7 +8638,15 @@
           "word": "wifey.",
           "start": 409.58,
           "end": 409.88
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 409.98,
+      "end": 410.9,
+      "text": "Oh, now, bad wifey them.",
+      "words": [
         {
           "word": "Oh,",
           "start": 409.98,
@@ -7694,7 +8671,15 @@
           "word": "them.",
           "start": 410.7,
           "end": 410.9
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 411.08,
+      "end": 412.6,
+      "text": "They've got bars, we've got bars.",
+      "words": [
         {
           "word": "They've",
           "start": 411.08,
@@ -7714,16 +8699,7 @@
           "word": "we've",
           "start": 412.06,
           "end": 412.26
-        }
-      ],
-      "speaker": "Footsie"
-    },
-    {
-      "id": 111,
-      "start": 412.26,
-      "end": 416.52,
-      "text": "got bars. Everybody knows that we're better than them. Damn, you don't",
-      "words": [
+        },
         {
           "word": "got",
           "start": 412.26,
@@ -7733,7 +8709,15 @@
           "word": "bars.",
           "start": 412.36,
           "end": 412.6
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 412.72,
+      "end": 414.5,
+      "text": "Everybody knows that we're better than them.",
+      "words": [
         {
           "word": "Everybody",
           "start": 412.72,
@@ -7768,7 +8752,15 @@
           "word": "them.",
           "start": 414.1,
           "end": 414.5
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 414.96,
+      "end": 416.52,
+      "text": "Damn, you don't",
+      "words": [
         {
           "word": "Damn,",
           "start": 414.96,
@@ -7788,10 +8780,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 112,
       "start": 416.52,
-      "end": 418.98,
-      "text": "know who I be talking to. Don't know if you get deaf",
+      "end": 417.74,
+      "text": "know who I be talking to.",
       "words": [
         {
           "word": "know",
@@ -7822,7 +8813,15 @@
           "word": "to.",
           "start": 417.36,
           "end": 417.74
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 418.14,
+      "end": 419.22,
+      "text": "Don't know if you get deaf or not.",
+      "words": [
         {
           "word": "Don't",
           "start": 418.14,
@@ -7852,16 +8851,7 @@
           "word": "deaf",
           "start": 418.82,
           "end": 418.98
-        }
-      ],
-      "speaker": "Footsie"
-    },
-    {
-      "id": 113,
-      "start": 418.98,
-      "end": 422.06,
-      "text": "or not. I think when we a double, come rolling through. Through,",
-      "words": [
+        },
         {
           "word": "or",
           "start": 418.98,
@@ -7871,7 +8861,15 @@
           "word": "not.",
           "start": 419.1,
           "end": 419.22
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 419.36,
+      "end": 421.16,
+      "text": "I think when we a double, come rolling through.",
+      "words": [
         {
           "word": "I",
           "start": 419.36,
@@ -7916,21 +8914,20 @@
           "word": "through.",
           "start": 420.78,
           "end": 421.16
-        },
-        {
-          "word": "Through,",
-          "start": 421.66,
-          "end": 422.06
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 114,
-      "start": 422.52,
-      "end": 426.0,
-      "text": "through. Rolling him and I'll roll on you. Rolling anyone who you",
+      "start": 421.66,
+      "end": 424.58,
+      "text": "Through, through. Rolling him and I'll roll on you.",
       "words": [
+        {
+          "word": "Through,",
+          "start": 421.66,
+          "end": 422.06
+        },
         {
           "word": "through.",
           "start": 422.52,
@@ -7970,7 +8967,15 @@
           "word": "you.",
           "start": 424.36,
           "end": 424.58
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 424.88,
+      "end": 426.0,
+      "text": "Rolling anyone who you",
+      "words": [
         {
           "word": "Rolling",
           "start": 424.88,
@@ -7995,10 +9000,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 115,
       "start": 426.0,
-      "end": 430.26,
-      "text": "be rolling with. Because that's what I'm rolling to. Through, melee, you're",
+      "end": 426.66,
+      "text": "be rolling with.",
       "words": [
         {
           "word": "be",
@@ -8014,7 +9018,15 @@
           "word": "with.",
           "start": 426.4,
           "end": 426.66
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 426.84,
+      "end": 428.04,
+      "text": "Because that's what I'm rolling to.",
+      "words": [
         {
           "word": "Because",
           "start": 426.84,
@@ -8044,7 +9056,15 @@
           "word": "to.",
           "start": 427.66,
           "end": 428.04
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 429.04,
+      "end": 430.26,
+      "text": "Through, melee, you're",
+      "words": [
         {
           "word": "Through,",
           "start": 429.04,
@@ -8064,10 +9084,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 116,
       "start": 430.26,
-      "end": 436.5,
-      "text": "not a bad boy. Don't be silly. You're a bad boy. You're",
+      "end": 430.8,
+      "text": "not a bad boy.",
       "words": [
         {
           "word": "not",
@@ -8088,7 +9107,15 @@
           "word": "boy.",
           "start": 430.6,
           "end": 430.8
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 430.9,
+      "end": 431.44,
+      "text": "Don't be silly.",
+      "words": [
         {
           "word": "Don't",
           "start": 430.9,
@@ -8103,7 +9130,15 @@
           "word": "silly.",
           "start": 431.18,
           "end": 431.44
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 431.76,
+      "end": 436.5,
+      "text": "You're a bad boy. You're",
+      "words": [
         {
           "word": "You're",
           "start": 431.76,
@@ -8133,10 +9168,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 117,
       "start": 436.5,
-      "end": 438.18,
-      "text": "a bad boy. You're a bad boy. You're a bad boy for",
+      "end": 437.16,
+      "text": "a bad boy.",
       "words": [
         {
           "word": "a",
@@ -8152,7 +9186,15 @@
           "word": "boy.",
           "start": 436.9,
           "end": 437.16
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 437.24,
+      "end": 438.0,
+      "text": "You're a bad boy.",
+      "words": [
         {
           "word": "You're",
           "start": 437.24,
@@ -8172,7 +9214,15 @@
           "word": "boy.",
           "start": 437.84,
           "end": 438.0
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 438.16,
+      "end": 438.38,
+      "text": "You're a bad boy for them.",
+      "words": [
         {
           "word": "You're",
           "start": 438.16,
@@ -8197,21 +9247,20 @@
           "word": "for",
           "start": 438.16,
           "end": 438.18
+        },
+        {
+          "word": "them.",
+          "start": 438.18,
+          "end": 438.38
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 118,
-      "start": 438.18,
-      "end": 441.86,
-      "text": "them. It's a lovin' in at the mix. And I rake and",
+      "start": 439.78000000000003,
+      "end": 441.3,
+      "text": "It's a lovin' in at the mix.",
       "words": [
-        {
-          "word": "them.",
-          "start": 438.18,
-          "end": 438.38
-        },
         {
           "word": "It's",
           "start": 439.78000000000003,
@@ -8246,7 +9295,15 @@
           "word": "mix.",
           "start": 441.12,
           "end": 441.3
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 441.44,
+      "end": 442.22,
+      "text": "And I rake and I blend.",
+      "words": [
         {
           "word": "And",
           "start": 441.44,
@@ -8266,16 +9323,7 @@
           "word": "and",
           "start": 441.7,
           "end": 441.86
-        }
-      ],
-      "speaker": "Footsie"
-    },
-    {
-      "id": 119,
-      "start": 441.86,
-      "end": 445.0,
-      "text": "I blend. Bad boy for you and I'm a bad boy for",
-      "words": [
+        },
         {
           "word": "I",
           "start": 441.86,
@@ -8285,7 +9333,15 @@
           "word": "blend.",
           "start": 441.98,
           "end": 442.22
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 443.42,
+      "end": 444.84,
+      "text": "Bad boy for you and I'm a bad boy",
+      "words": [
         {
           "word": "Bad",
           "start": 443.42,
@@ -8330,21 +9386,20 @@
           "word": "boy",
           "start": 444.72,
           "end": 444.84
-        },
-        {
-          "word": "for",
-          "start": 444.84,
-          "end": 445.0
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 120,
-      "start": 445.0,
-      "end": 455.56,
-      "text": "them. Oh, my God. Bad, bad, bad. It's ooh, ooh. Serious. Dirty,",
+      "start": 444.84,
+      "end": 447.54,
+      "text": "for them. Oh, my God.",
       "words": [
+        {
+          "word": "for",
+          "start": 444.84,
+          "end": 445.0
+        },
         {
           "word": "them.",
           "start": 445.0,
@@ -8364,7 +9419,15 @@
           "word": "God.",
           "start": 447.06,
           "end": 447.54
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 448.26,
+      "end": 448.84,
+      "text": "Bad, bad, bad.",
+      "words": [
         {
           "word": "Bad,",
           "start": 448.26,
@@ -8379,7 +9442,15 @@
           "word": "bad.",
           "start": 448.74,
           "end": 448.84
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 451.06,
+      "end": 455.56,
+      "text": "It's ooh, ooh. Serious. Dirty,",
+      "words": [
         {
           "word": "It's",
           "start": 451.06,
@@ -8409,10 +9480,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 121,
       "start": 455.78,
-      "end": 465.12,
-      "text": "t. That's ooh, ooh. Bad, bad, bad. In a war, know that",
+      "end": 459.5,
+      "text": "t. That's ooh, ooh.",
       "words": [
         {
           "word": "t.",
@@ -8433,7 +9503,15 @@
           "word": "ooh.",
           "start": 459.3,
           "end": 459.5
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 461.66,
+      "end": 462.5,
+      "text": "Bad, bad, bad.",
+      "words": [
         {
           "word": "Bad,",
           "start": 461.66,
@@ -8448,7 +9526,15 @@
           "word": "bad.",
           "start": 462.28,
           "end": 462.5
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 463.84000000000003,
+      "end": 465.12,
+      "text": "In a war, know that",
+      "words": [
         {
           "word": "In",
           "start": 463.84000000000003,
@@ -8478,10 +9564,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 122,
       "start": 465.12,
-      "end": 467.44,
-      "text": "I do my thing. My want to try and do my thing.",
+      "end": 465.88,
+      "text": "I do my thing.",
       "words": [
         {
           "word": "I",
@@ -8502,7 +9587,15 @@
           "word": "thing.",
           "start": 465.52,
           "end": 465.88
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 466.14,
+      "end": 467.44,
+      "text": "My want to try and do my thing.",
+      "words": [
         {
           "word": "My",
           "start": 466.14,
@@ -8547,10 +9640,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 123,
       "start": 467.5,
-      "end": 469.58,
-      "text": "Don't go on like saying it's a new my thing. Call I",
+      "end": 468.96,
+      "text": "Don't go on like saying it's a new my",
       "words": [
         {
           "word": "Don't",
@@ -8596,7 +9688,15 @@
           "word": "my",
           "start": 468.74,
           "end": 468.96
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 468.96,
+      "end": 469.58,
+      "text": "thing. Call I",
+      "words": [
         {
           "word": "thing.",
           "start": 468.96,
@@ -8616,10 +9716,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 124,
       "start": 469.58,
-      "end": 471.3,
-      "text": "do what I want to make it a high thing. You know,",
+      "end": 470.68,
+      "text": "do what I want to make it a high",
       "words": [
         {
           "word": "do",
@@ -8665,7 +9764,15 @@
           "word": "high",
           "start": 470.54,
           "end": 470.68
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 470.68,
+      "end": 471.3,
+      "text": "thing. You know,",
+      "words": [
         {
           "word": "thing.",
           "start": 470.68,
@@ -8685,10 +9792,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 125,
       "start": 471.72,
-      "end": 473.44,
-      "text": "when they come to my thing. My the baby from the war,",
+      "end": 472.62,
+      "text": "when they come to my thing.",
       "words": [
         {
           "word": "when",
@@ -8719,7 +9825,15 @@
           "word": "thing.",
           "start": 472.4,
           "end": 472.62
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 472.7,
+      "end": 473.44,
+      "text": "My the baby from the war,",
+      "words": [
         {
           "word": "My",
           "start": 472.7,
@@ -8754,10 +9868,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 126,
       "start": 473.5,
-      "end": 476.72,
-      "text": "just like a Viking. And the MC that I'm not liking. Stop",
+      "end": 474.12,
+      "text": "just like a Viking.",
       "words": [
         {
           "word": "just",
@@ -8778,7 +9891,15 @@
           "word": "Viking.",
           "start": 473.92,
           "end": 474.12
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 474.76,
+      "end": 476.72,
+      "text": "And the MC that I'm not liking. Stop",
+      "words": [
         {
           "word": "And",
           "start": 474.76,
@@ -8823,10 +9944,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 127,
       "start": 476.72,
-      "end": 480.16,
-      "text": "waving goodbye king. Call when they come to the classroom. They're mine",
+      "end": 477.84,
+      "text": "waving goodbye king.",
       "words": [
         {
           "word": "waving",
@@ -8842,7 +9962,15 @@
           "word": "king.",
           "start": 477.4,
           "end": 477.84
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 478.28,
+      "end": 480.16,
+      "text": "Call when they come to the classroom. They're mine",
+      "words": [
         {
           "word": "Call",
           "start": 478.28,
@@ -8892,10 +10020,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 128,
       "start": 480.16,
-      "end": 483.38,
-      "text": "too when they're pirating. But don't get no high rating from me.",
+      "end": 481.04,
+      "text": "too when they're pirating.",
       "words": [
         {
           "word": "too",
@@ -8916,7 +10043,15 @@
           "word": "pirating.",
           "start": 480.62,
           "end": 481.04
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 481.32,
+      "end": 483.38,
+      "text": "But don't get no high rating from me.",
+      "words": [
         {
           "word": "But",
           "start": 481.32,
@@ -8961,10 +10096,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 129,
       "start": 483.62,
-      "end": 487.28,
-      "text": "Not lovin' no AMC like me. I've won the MC. Maybe, watching",
+      "end": 485.04,
+      "text": "Not lovin' no AMC like me.",
       "words": [
         {
           "word": "Not",
@@ -8995,7 +10129,15 @@
           "word": "me.",
           "start": 484.76,
           "end": 485.04
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 485.42,
+      "end": 487.64,
+      "text": "I've won the MC. Maybe, watching the MC.",
+      "words": [
         {
           "word": "I've",
           "start": 485.42,
@@ -9025,16 +10167,7 @@
           "word": "watching",
           "start": 487.04,
           "end": 487.28
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 130,
-      "start": 487.28,
-      "end": 491.0,
-      "text": "the MC. I'm gonna try and lead the poverty. Well, well, well.",
-      "words": [
+        },
         {
           "word": "the",
           "start": 487.28,
@@ -9044,7 +10177,15 @@
           "word": "MC.",
           "start": 487.46,
           "end": 487.64
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 488.0,
+      "end": 489.26,
+      "text": "I'm gonna try and lead the poverty.",
+      "words": [
         {
           "word": "I'm",
           "start": 488.0,
@@ -9079,7 +10220,15 @@
           "word": "poverty.",
           "start": 489.04,
           "end": 489.26
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 490.0,
+      "end": 491.0,
+      "text": "Well, well, well.",
+      "words": [
         {
           "word": "Well,",
           "start": 490.0,
@@ -9099,10 +10248,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 131,
       "start": 491.46,
-      "end": 494.26,
-      "text": "Don't think you can screw me cause you're boffin' cause JME don't",
+      "end": 493.2,
+      "text": "Don't think you can screw me cause you're boffin'",
       "words": [
         {
           "word": "Don't",
@@ -9148,7 +10296,15 @@
           "word": "boffin'",
           "start": 492.94,
           "end": 493.2
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 493.26,
+      "end": 494.26,
+      "text": "cause JME don't",
+      "words": [
         {
           "word": "cause",
           "start": 493.26,
@@ -9168,10 +10324,9 @@
       "speaker": "JME"
     },
     {
-      "id": 132,
       "start": 494.26,
-      "end": 496.74,
-      "text": "care about nothin'. I'll cross the road and do my sign like",
+      "end": 495.0,
+      "text": "care about nothin'.",
       "words": [
         {
           "word": "care",
@@ -9187,7 +10342,15 @@
           "word": "nothin'.",
           "start": 494.58,
           "end": 495.0
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 495.0,
+      "end": 496.74,
+      "text": "I'll cross the road and do my sign like",
+      "words": [
         {
           "word": "I'll",
           "start": 495.0,
@@ -9237,10 +10400,9 @@
       "speaker": "JME"
     },
     {
-      "id": 133,
       "start": 496.74,
-      "end": 499.4,
-      "text": "blam. You gotta punch in the jaw like blam. Check your face",
+      "end": 498.8,
+      "text": "blam. You gotta punch in the jaw like blam.",
       "words": [
         {
           "word": "blam.",
@@ -9286,7 +10448,15 @@
           "word": "blam.",
           "start": 498.46,
           "end": 498.8
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 498.96,
+      "end": 499.4,
+      "text": "Check your face",
+      "words": [
         {
           "word": "Check",
           "start": 498.96,
@@ -9306,10 +10476,9 @@
       "speaker": "JME"
     },
     {
-      "id": 134,
       "start": 499.4,
-      "end": 502.5,
-      "text": "cross the floor like blam. Do that elbow drop like blam. You",
+      "end": 500.46,
+      "text": "cross the floor like blam.",
       "words": [
         {
           "word": "cross",
@@ -9335,7 +10504,15 @@
           "word": "blam.",
           "start": 500.14,
           "end": 500.46
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 500.72,
+      "end": 502.5,
+      "text": "Do that elbow drop like blam. You",
+      "words": [
         {
           "word": "Do",
           "start": 500.72,
@@ -9375,10 +10552,9 @@
       "speaker": "JME"
     },
     {
-      "id": 135,
       "start": 502.5,
-      "end": 505.94,
-      "text": "gotta hit, I said well, well, well. Don't think you can screw",
+      "end": 504.56,
+      "text": "gotta hit, I said well, well, well.",
       "words": [
         {
           "word": "gotta",
@@ -9414,7 +10590,15 @@
           "word": "well.",
           "start": 504.4,
           "end": 504.56
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 505.2,
+      "end": 505.94,
+      "text": "Don't think you can screw",
+      "words": [
         {
           "word": "Don't",
           "start": 505.2,
@@ -9444,10 +10628,9 @@
       "speaker": "JME"
     },
     {
-      "id": 136,
       "start": 505.94,
-      "end": 507.94,
-      "text": "me cause you're at work. You can be the boss for the",
+      "end": 506.84,
+      "text": "me cause you're at work.",
       "words": [
         {
           "word": "me",
@@ -9473,7 +10656,15 @@
           "word": "work.",
           "start": 506.6,
           "end": 506.84
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 507.12,
+      "end": 508.52,
+      "text": "You can be the boss for the office club.",
+      "words": [
         {
           "word": "You",
           "start": 507.12,
@@ -9508,16 +10699,7 @@
           "word": "the",
           "start": 507.86,
           "end": 507.94
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 137,
-      "start": 507.94,
-      "end": 510.78,
-      "text": "office club. I'll roll my sleeves up and go berserk like blam.",
-      "words": [
+        },
         {
           "word": "office",
           "start": 507.94,
@@ -9527,7 +10709,15 @@
           "word": "club.",
           "start": 508.26,
           "end": 508.52
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 508.66,
+      "end": 510.42,
+      "text": "I'll roll my sleeves up and go berserk like",
+      "words": [
         {
           "word": "I'll",
           "start": 508.66,
@@ -9572,21 +10762,20 @@
           "word": "like",
           "start": 510.24,
           "end": 510.42
-        },
-        {
-          "word": "blam.",
-          "start": 510.42,
-          "end": 510.78
         }
       ],
       "speaker": "JME"
     },
     {
-      "id": 138,
-      "start": 511.02,
-      "end": 513.18,
-      "text": "Dash your head off the screen like blam. Click your head in",
+      "start": 510.42,
+      "end": 512.48,
+      "text": "blam. Dash your head off the screen like blam.",
       "words": [
+        {
+          "word": "blam.",
+          "start": 510.42,
+          "end": 510.78
+        },
         {
           "word": "Dash",
           "start": 511.02,
@@ -9626,7 +10815,15 @@
           "word": "blam.",
           "start": 512.16,
           "end": 512.48
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 512.72,
+      "end": 513.18,
+      "text": "Click your head in",
+      "words": [
         {
           "word": "Click",
           "start": 512.72,
@@ -9651,10 +10848,9 @@
       "speaker": "JME"
     },
     {
-      "id": 139,
       "start": 513.18,
-      "end": 515.6,
-      "text": "the keyboard like blam. Dash your head out of the room like",
+      "end": 514.18,
+      "text": "the keyboard like blam.",
       "words": [
         {
           "word": "the",
@@ -9675,7 +10871,15 @@
           "word": "blam.",
           "start": 513.84,
           "end": 514.18
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 514.18,
+      "end": 515.88,
+      "text": "Dash your head out of the room like blam.",
+      "words": [
         {
           "word": "Dash",
           "start": 514.18,
@@ -9715,21 +10919,20 @@
           "word": "like",
           "start": 515.44,
           "end": 515.6
+        },
+        {
+          "word": "blam.",
+          "start": 515.6,
+          "end": 515.88
         }
       ],
       "speaker": "JME"
     },
     {
-      "id": 140,
-      "start": 515.6,
-      "end": 519.32,
-      "text": "blam. Clink into the water cool off. Well, well, well. Don't try",
+      "start": 516.0,
+      "end": 517.34,
+      "text": "Clink into the water cool off.",
       "words": [
-        {
-          "word": "blam.",
-          "start": 515.6,
-          "end": 515.88
-        },
         {
           "word": "Clink",
           "start": 516.0,
@@ -9759,7 +10962,15 @@
           "word": "off.",
           "start": 517.14,
           "end": 517.34
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 517.52,
+      "end": 519.32,
+      "text": "Well, well, well. Don't try",
+      "words": [
         {
           "word": "Well,",
           "start": 517.52,
@@ -9789,10 +11000,9 @@
       "speaker": "JME"
     },
     {
-      "id": 141,
       "start": 519.32,
-      "end": 522.12,
-      "text": "this man on the YouTube. I don't know why you think you",
+      "end": 520.46,
+      "text": "this man on the YouTube.",
       "words": [
         {
           "word": "this",
@@ -9818,7 +11028,15 @@
           "word": "YouTube.",
           "start": 520.18,
           "end": 520.46
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 520.7,
+      "end": 522.12,
+      "text": "I don't know why you think you",
+      "words": [
         {
           "word": "I",
           "start": 520.7,
@@ -9858,10 +11076,9 @@
       "speaker": "JME"
     },
     {
-      "id": 142,
       "start": 522.12,
-      "end": 524.42,
-      "text": "can get tiger up a car. Out of the ring like blam.",
+      "end": 523.34,
+      "text": "can get tiger up a car.",
       "words": [
         {
           "word": "can",
@@ -9892,7 +11109,15 @@
           "word": "car.",
           "start": 523.3,
           "end": 523.34
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 523.6,
+      "end": 524.42,
+      "text": "Out of the ring like blam.",
+      "words": [
         {
           "word": "Out",
           "start": 523.6,
@@ -9927,10 +11152,9 @@
       "speaker": "JME"
     },
     {
-      "id": 143,
       "start": 524.74,
-      "end": 527.6,
-      "text": "You gotta knock through 10 like blam. You gotta argue girl like",
+      "end": 526.14,
+      "text": "You gotta knock through 10 like blam.",
       "words": [
         {
           "word": "You",
@@ -9966,7 +11190,15 @@
           "word": "blam.",
           "start": 525.82,
           "end": 526.14
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 526.46,
+      "end": 527.86,
+      "text": "You gotta argue girl like blam.",
+      "words": [
         {
           "word": "You",
           "start": 526.46,
@@ -9991,21 +11223,20 @@
           "word": "like",
           "start": 527.48,
           "end": 527.6
+        },
+        {
+          "word": "blam.",
+          "start": 527.6,
+          "end": 527.86
         }
       ],
       "speaker": "JME"
     },
     {
-      "id": 144,
-      "start": 527.6,
-      "end": 530.58,
-      "text": "blam. You gotta tag a nail like blam. Do that punch in",
+      "start": 528.16,
+      "end": 529.6,
+      "text": "You gotta tag a nail like blam.",
       "words": [
-        {
-          "word": "blam.",
-          "start": 527.6,
-          "end": 527.86
-        },
         {
           "word": "You",
           "start": 528.16,
@@ -10040,7 +11271,15 @@
           "word": "blam.",
           "start": 529.3,
           "end": 529.6
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 529.84,
+      "end": 530.58,
+      "text": "Do that punch in",
+      "words": [
         {
           "word": "Do",
           "start": 529.84,
@@ -10065,10 +11304,9 @@
       "speaker": "JME"
     },
     {
-      "id": 145,
       "start": 530.58,
-      "end": 532.84,
-      "text": "the jaw like. You know that race just full of dead rats.",
+      "end": 531.04,
+      "text": "the jaw like.",
       "words": [
         {
           "word": "the",
@@ -10084,7 +11322,15 @@
           "word": "like.",
           "start": 530.82,
           "end": 531.04
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 531.18,
+      "end": 532.42,
+      "text": "You know that race just full of dead",
+      "words": [
         {
           "word": "You",
           "start": 531.18,
@@ -10124,21 +11370,20 @@
           "word": "dead",
           "start": 532.24,
           "end": 532.42
-        },
-        {
-          "word": "rats.",
-          "start": 532.42,
-          "end": 532.84
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 146,
-      "start": 533.28,
-      "end": 536.18,
-      "text": "Over us. Get that grinding high and do the death trap. Spoken",
+      "start": 532.42,
+      "end": 533.84,
+      "text": "rats. Over us.",
       "words": [
+        {
+          "word": "rats.",
+          "start": 532.42,
+          "end": 532.84
+        },
         {
           "word": "Over",
           "start": 533.28,
@@ -10148,7 +11393,15 @@
           "word": "us.",
           "start": 533.62,
           "end": 533.84
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 534.06,
+      "end": 535.78,
+      "text": "Get that grinding high and do the death trap.",
+      "words": [
         {
           "word": "Get",
           "start": 534.06,
@@ -10193,21 +11446,20 @@
           "word": "trap.",
           "start": 535.6,
           "end": 535.78
-        },
-        {
-          "word": "Spoken",
-          "start": 535.98,
-          "end": 536.18
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 147,
-      "start": 536.18,
-      "end": 538.74,
-      "text": "a spliff while writing an X -Rap. Track no goals. Is it",
+      "start": 535.98,
+      "end": 537.52,
+      "text": "Spoken a spliff while writing an X -Rap.",
       "words": [
+        {
+          "word": "Spoken",
+          "start": 535.98,
+          "end": 536.18
+        },
         {
           "word": "a",
           "start": 536.18,
@@ -10242,7 +11494,15 @@
           "word": "-Rap.",
           "start": 537.34,
           "end": 537.52
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 537.6,
+      "end": 538.74,
+      "text": "Track no goals. Is it",
+      "words": [
         {
           "word": "Track",
           "start": 537.6,
@@ -10272,10 +11532,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 148,
       "start": 538.74,
-      "end": 540.74,
-      "text": "the face, my brother? It's an X -Cat. Get on the scales",
+      "end": 539.36,
+      "text": "the face, my brother?",
       "words": [
         {
           "word": "the",
@@ -10296,7 +11555,15 @@
           "word": "brother?",
           "start": 539.2,
           "end": 539.36
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 539.54,
+      "end": 540.04,
+      "text": "It's an X -Cat.",
+      "words": [
         {
           "word": "It's",
           "start": 539.54,
@@ -10316,7 +11583,15 @@
           "word": "-Cat.",
           "start": 539.84,
           "end": 540.04
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 540.04,
+      "end": 540.74,
+      "text": "Get on the scales",
+      "words": [
         {
           "word": "Get",
           "start": 540.04,
@@ -10341,10 +11616,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 149,
       "start": 540.74,
-      "end": 543.12,
-      "text": "and weigh out an X -Rap. Get a grind, keep going. Jack",
+      "end": 541.96,
+      "text": "and weigh out an X -Rap.",
       "words": [
         {
           "word": "and",
@@ -10375,7 +11649,15 @@
           "word": "-Rap.",
           "start": 541.58,
           "end": 541.96
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 542.0,
+      "end": 543.12,
+      "text": "Get a grind, keep going. Jack",
+      "words": [
         {
           "word": "Get",
           "start": 542.0,
@@ -10410,10 +11692,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 150,
       "start": 543.12,
-      "end": 545.96,
-      "text": "is mid a in -sport. I keep blowing. I keep showing. All",
+      "end": 543.9,
+      "text": "is mid a in -sport.",
       "words": [
         {
           "word": "is",
@@ -10439,7 +11720,15 @@
           "word": "-sport.",
           "start": 543.68,
           "end": 543.9
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 544.06,
+      "end": 544.58,
+      "text": "I keep blowing.",
+      "words": [
         {
           "word": "I",
           "start": 544.06,
@@ -10454,7 +11743,15 @@
           "word": "blowing.",
           "start": 544.3,
           "end": 544.58
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 544.96,
+      "end": 545.96,
+      "text": "I keep showing. All",
+      "words": [
         {
           "word": "I",
           "start": 544.96,
@@ -10479,10 +11776,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 151,
       "start": 545.96,
-      "end": 548.5,
-      "text": "of your hits. I'm gonna eat up all of your papers. Oh",
+      "end": 546.38,
+      "text": "of your hits.",
       "words": [
         {
           "word": "of",
@@ -10498,7 +11794,15 @@
           "word": "hits.",
           "start": 546.18,
           "end": 546.38
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 546.72,
+      "end": 548.5,
+      "text": "I'm gonna eat up all of your papers. Oh",
+      "words": [
         {
           "word": "I'm",
           "start": 546.72,
@@ -10548,10 +11852,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 152,
       "start": 548.5,
-      "end": 552.12,
-      "text": "no, not talking Mr. Bandana and the Dark Soul like Sizzler. Mastana",
+      "end": 549.74,
+      "text": "no, not talking Mr.",
       "words": [
         {
           "word": "no,",
@@ -10572,7 +11875,15 @@
           "word": "Mr.",
           "start": 549.38,
           "end": 549.74
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 550.04,
+      "end": 552.12,
+      "text": "Bandana and the Dark Soul like Sizzler. Mastana",
+      "words": [
         {
           "word": "Bandana",
           "start": 550.04,
@@ -10617,10 +11928,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 153,
       "start": 552.12,
-      "end": 554.66,
-      "text": "and the MC like Ninja. In the war I would more than",
+      "end": 553.16,
+      "text": "and the MC like Ninja.",
       "words": [
         {
           "word": "and",
@@ -10646,7 +11956,15 @@
           "word": "Ninja.",
           "start": 552.9,
           "end": 553.16
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 553.52,
+      "end": 554.66,
+      "text": "In the war I would more than",
+      "words": [
         {
           "word": "In",
           "start": 553.52,
@@ -10686,10 +12004,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 154,
       "start": 554.66,
-      "end": 557.52,
-      "text": "injure a guy. Start that ninja by guiding your thunder. I'm moving",
+      "end": 555.34,
+      "text": "injure a guy.",
       "words": [
         {
           "word": "injure",
@@ -10705,7 +12022,15 @@
           "word": "guy.",
           "start": 555.12,
           "end": 555.34
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 555.62,
+      "end": 557.52,
+      "text": "Start that ninja by guiding your thunder. I'm moving",
+      "words": [
         {
           "word": "Start",
           "start": 555.62,
@@ -10755,10 +12080,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 155,
       "start": 557.52,
-      "end": 561.74,
-      "text": "ninja by life. I'm that guy. Everyone wants to be my code.",
+      "end": 558.5,
+      "text": "ninja by life.",
       "words": [
         {
           "word": "ninja",
@@ -10774,7 +12098,15 @@
           "word": "life.",
           "start": 558.14,
           "end": 558.5
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 559.28,
+      "end": 560.16,
+      "text": "I'm that guy.",
+      "words": [
         {
           "word": "I'm",
           "start": 559.28,
@@ -10789,7 +12121,15 @@
           "word": "guy.",
           "start": 559.78,
           "end": 560.16
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 560.52,
+      "end": 561.74,
+      "text": "Everyone wants to be my code.",
+      "words": [
         {
           "word": "Everyone",
           "start": 560.52,
@@ -10824,10 +12164,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 156,
       "start": 562.16,
-      "end": 564.46,
-      "text": "Cause you know you want me a you. To get a perfect",
+      "end": 563.34,
+      "text": "Cause you know you want me a you.",
       "words": [
         {
           "word": "Cause",
@@ -10868,7 +12207,15 @@
           "word": "you.",
           "start": 563.2,
           "end": 563.34
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 563.8,
+      "end": 564.46,
+      "text": "To get a perfect",
+      "words": [
         {
           "word": "To",
           "start": 563.8,
@@ -10893,10 +12240,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 157,
       "start": 564.46,
-      "end": 566.94,
-      "text": "or get close. Let me get them out of the cool doors.",
+      "end": 565.22,
+      "text": "or get close.",
       "words": [
         {
           "word": "or",
@@ -10912,7 +12258,15 @@
           "word": "close.",
           "start": 564.92,
           "end": 565.22
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 565.7,
+      "end": 566.94,
+      "text": "Let me get them out of the cool doors.",
+      "words": [
         {
           "word": "Let",
           "start": 565.7,
@@ -10962,10 +12316,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 158,
       "start": 567.3,
-      "end": 569.7,
-      "text": "This actually can put on my get rolls. As soon as I",
+      "end": 568.68,
+      "text": "This actually can put on my get rolls.",
       "words": [
         {
           "word": "This",
@@ -11006,7 +12359,15 @@
           "word": "rolls.",
           "start": 568.36,
           "end": 568.68
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 568.68,
+      "end": 569.7,
+      "text": "As soon as I",
+      "words": [
         {
           "word": "As",
           "start": 568.68,
@@ -11031,10 +12392,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 159,
       "start": 569.7,
-      "end": 572.64,
-      "text": "box my soul for the whole park. Cause I'm an old school",
+      "end": 571.6,
+      "text": "box my soul for the whole park.",
       "words": [
         {
           "word": "box",
@@ -11070,7 +12430,15 @@
           "word": "park.",
           "start": 570.9,
           "end": 571.6
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 571.62,
+      "end": 572.94,
+      "text": "Cause I'm an old school G.",
+      "words": [
         {
           "word": "Cause",
           "start": 571.62,
@@ -11095,21 +12463,20 @@
           "word": "school",
           "start": 572.42,
           "end": 572.64
+        },
+        {
+          "word": "G.",
+          "start": 572.64,
+          "end": 572.94
         }
       ],
       "speaker": "D Double E"
     },
     {
-      "id": 160,
-      "start": 572.64,
-      "end": 575.84,
-      "text": "G. Just like you can hit him with the argue. Can match",
+      "start": 573.1,
+      "end": 574.76,
+      "text": "Just like you can hit him with the argue.",
       "words": [
-        {
-          "word": "G.",
-          "start": 572.64,
-          "end": 572.94
-        },
         {
           "word": "Just",
           "start": 573.1,
@@ -11154,7 +12521,15 @@
           "word": "argue.",
           "start": 574.5,
           "end": 574.76
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 574.96,
+      "end": 577.4,
+      "text": "Can match my level and see your two -kun.",
+      "words": [
         {
           "word": "Can",
           "start": 574.96,
@@ -11164,16 +12539,7 @@
           "word": "match",
           "start": 575.06,
           "end": 575.84
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 161,
-      "start": 575.84,
-      "end": 578.64,
-      "text": "my level and see your two -kun. Beat this, let's see your",
-      "words": [
+        },
         {
           "word": "my",
           "start": 575.84,
@@ -11208,7 +12574,15 @@
           "word": "-kun.",
           "start": 577.1,
           "end": 577.4
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 577.6,
+      "end": 579.02,
+      "text": "Beat this, let's see your two -kun.",
+      "words": [
         {
           "word": "Beat",
           "start": 577.6,
@@ -11233,16 +12607,7 @@
           "word": "your",
           "start": 578.44,
           "end": 578.64
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 162,
-      "start": 578.64,
-      "end": 581.12,
-      "text": "two -kun. You better charge. You better cheer me up and control",
-      "words": [
+        },
         {
           "word": "two",
           "start": 578.64,
@@ -11252,7 +12617,15 @@
           "word": "-kun.",
           "start": 578.82,
           "end": 579.02
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 579.16,
+      "end": 579.8,
+      "text": "You better charge.",
+      "words": [
         {
           "word": "You",
           "start": 579.16,
@@ -11267,7 +12640,15 @@
           "word": "charge.",
           "start": 579.44,
           "end": 579.8
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 580.18,
+      "end": 581.62,
+      "text": "You better cheer me up and control my eye.",
+      "words": [
         {
           "word": "You",
           "start": 580.18,
@@ -11302,16 +12683,7 @@
           "word": "control",
           "start": 581.02,
           "end": 581.12
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 163,
-      "start": 581.12,
-      "end": 584.42,
-      "text": "my eye. See the fury here be pissed. Like a Ruri sick",
-      "words": [
+        },
         {
           "word": "my",
           "start": 581.12,
@@ -11321,7 +12693,15 @@
           "word": "eye.",
           "start": 581.28,
           "end": 581.62
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 581.88,
+      "end": 583.3,
+      "text": "See the fury here be pissed.",
+      "words": [
         {
           "word": "See",
           "start": 581.88,
@@ -11351,7 +12731,15 @@
           "word": "pissed.",
           "start": 582.88,
           "end": 583.3
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 583.58,
+      "end": 584.42,
+      "text": "Like a Ruri sick",
+      "words": [
         {
           "word": "Like",
           "start": 583.58,
@@ -11376,10 +12764,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 164,
       "start": 584.42,
-      "end": 587.22,
-      "text": "in the head. No breathing can cure me. If it's me or",
+      "end": 584.84,
+      "text": "in the head.",
       "words": [
         {
           "word": "in",
@@ -11395,7 +12782,15 @@
           "word": "head.",
           "start": 584.68,
           "end": 584.84
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 584.94,
+      "end": 586.06,
+      "text": "No breathing can cure me.",
+      "words": [
         {
           "word": "No",
           "start": 584.94,
@@ -11420,7 +12815,15 @@
           "word": "me.",
           "start": 585.8,
           "end": 586.06
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 586.58,
+      "end": 587.56,
+      "text": "If it's me or my dad.",
+      "words": [
         {
           "word": "If",
           "start": 586.58,
@@ -11440,16 +12843,7 @@
           "word": "or",
           "start": 587.04,
           "end": 587.22
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 165,
-      "start": 587.22,
-      "end": 589.78,
-      "text": "my dad. You get a scar in the chest like Saga. She",
-      "words": [
+        },
         {
           "word": "my",
           "start": 587.22,
@@ -11459,7 +12853,15 @@
           "word": "dad.",
           "start": 587.4,
           "end": 587.56
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 587.84,
+      "end": 589.22,
+      "text": "You get a scar in the chest like Saga.",
+      "words": [
         {
           "word": "You",
           "start": 587.84,
@@ -11504,21 +12906,20 @@
           "word": "Saga.",
           "start": 588.92,
           "end": 589.22
-        },
-        {
-          "word": "She",
-          "start": 589.62,
-          "end": 589.78
         }
       ],
       "speaker": "D Double E"
     },
     {
-      "id": 166,
-      "start": 589.78,
-      "end": 593.28,
-      "text": "fighting that's what I'm about. My thing working. Perfect. Cause I come",
+      "start": 589.62,
+      "end": 590.88,
+      "text": "She fighting that's what I'm about.",
       "words": [
+        {
+          "word": "She",
+          "start": 589.62,
+          "end": 589.78
+        },
         {
           "word": "fighting",
           "start": 589.78,
@@ -11543,7 +12944,15 @@
           "word": "about.",
           "start": 590.72,
           "end": 590.88
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 591.08,
+      "end": 592.36,
+      "text": "My thing working. Perfect.",
+      "words": [
         {
           "word": "My",
           "start": 591.08,
@@ -11563,7 +12972,15 @@
           "word": "Perfect.",
           "start": 592.02,
           "end": 592.36
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 592.66,
+      "end": 593.28,
+      "text": "Cause I come",
+      "words": [
         {
           "word": "Cause",
           "start": 592.66,
@@ -11583,10 +13000,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 167,
       "start": 593.28,
-      "end": 595.4,
-      "text": "through when I beat up Honda. If I'm not on, just stop",
+      "end": 594.36,
+      "text": "through when I beat up Honda.",
       "words": [
         {
           "word": "through",
@@ -11617,7 +13033,15 @@
           "word": "Honda.",
           "start": 594.08,
           "end": 594.36
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 594.62,
+      "end": 595.82,
+      "text": "If I'm not on, just stop like it.",
+      "words": [
         {
           "word": "If",
           "start": 594.62,
@@ -11647,16 +13071,7 @@
           "word": "stop",
           "start": 595.22,
           "end": 595.4
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 168,
-      "start": 595.4,
-      "end": 597.68,
-      "text": "like it. Give it to Mike and then we ride. Invite them",
-      "words": [
+        },
         {
           "word": "like",
           "start": 595.4,
@@ -11666,7 +13081,15 @@
           "word": "it.",
           "start": 595.66,
           "end": 595.82
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 596.08,
+      "end": 597.28,
+      "text": "Give it to Mike and then we ride.",
+      "words": [
         {
           "word": "Give",
           "start": 596.08,
@@ -11706,7 +13129,15 @@
           "word": "ride.",
           "start": 597.1,
           "end": 597.28
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 597.42,
+      "end": 598.0,
+      "text": "Invite them to the fire.",
+      "words": [
         {
           "word": "Invite",
           "start": 597.42,
@@ -11716,16 +13147,7 @@
           "word": "them",
           "start": 597.5,
           "end": 597.68
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 169,
-      "start": 597.68,
-      "end": 601.66,
-      "text": "to the fire. Just like they'll sing. I'm an electrical invader. Find",
-      "words": [
+        },
         {
           "word": "to",
           "start": 597.68,
@@ -11740,7 +13162,15 @@
           "word": "fire.",
           "start": 597.96,
           "end": 598.0
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 598.76,
+      "end": 599.48,
+      "text": "Just like they'll sing.",
+      "words": [
         {
           "word": "Just",
           "start": 598.76,
@@ -11760,7 +13190,15 @@
           "word": "sing.",
           "start": 599.2,
           "end": 599.48
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 600.0,
+      "end": 601.66,
+      "text": "I'm an electrical invader. Find",
+      "words": [
         {
           "word": "I'm",
           "start": 600.0,
@@ -11790,10 +13228,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 170,
       "start": 601.66,
-      "end": 607.58,
-      "text": "me until the time feels like it. Cheezer. Trust me. Big up",
+      "end": 604.08,
+      "text": "me until the time feels like it. Cheezer.",
       "words": [
         {
           "word": "me",
@@ -11834,7 +13271,15 @@
           "word": "Cheezer.",
           "start": 603.5600000000001,
           "end": 604.08
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 605.62,
+      "end": 607.94,
+      "text": "Trust me. Big up Teddy.",
+      "words": [
         {
           "word": "Trust",
           "start": 605.62,
@@ -11854,21 +13299,20 @@
           "word": "up",
           "start": 607.42,
           "end": 607.58
+        },
+        {
+          "word": "Teddy.",
+          "start": 607.58,
+          "end": 607.94
         }
       ],
       "speaker": "D Double E"
     },
     {
-      "id": 171,
-      "start": 607.58,
-      "end": 613.96,
-      "text": "Teddy. Old type J and me in a building. It's Newham Generals.",
+      "start": 610.46,
+      "end": 612.36,
+      "text": "Old type J and me in a building.",
       "words": [
-        {
-          "word": "Teddy.",
-          "start": 607.58,
-          "end": 607.94
-        },
         {
           "word": "Old",
           "start": 610.46,
@@ -11908,7 +13352,15 @@
           "word": "building.",
           "start": 612.0,
           "end": 612.36
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 612.96,
+      "end": 614.94,
+      "text": "It's Newham Generals. Logan, Sama.",
+      "words": [
         {
           "word": "It's",
           "start": 612.96,
@@ -11923,16 +13375,7 @@
           "word": "Generals.",
           "start": 613.42,
           "end": 613.96
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 172,
-      "start": 614.16,
-      "end": 620.32,
-      "text": "Logan, Sama. Big up Skits. Supermotion day today. Blam bag of crease.",
-      "words": [
+        },
         {
           "word": "Logan,",
           "start": 614.16,
@@ -11942,7 +13385,15 @@
           "word": "Sama.",
           "start": 614.66,
           "end": 614.94
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 615.42,
+      "end": 616.34,
+      "text": "Big up Skits.",
+      "words": [
         {
           "word": "Big",
           "start": 615.42,
@@ -11957,7 +13408,15 @@
           "word": "Skits.",
           "start": 615.7,
           "end": 616.34
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 617.7,
+      "end": 618.88,
+      "text": "Supermotion day today.",
+      "words": [
         {
           "word": "Supermotion",
           "start": 617.7,
@@ -11972,7 +13431,15 @@
           "word": "today.",
           "start": 618.58,
           "end": 618.88
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 619.28,
+      "end": 621.22,
+      "text": "Blam bag of crease. Double B.",
+      "words": [
         {
           "word": "Blam",
           "start": 619.28,
@@ -11992,16 +13459,7 @@
           "word": "crease.",
           "start": 620.04,
           "end": 620.32
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 173,
-      "start": 620.5,
-      "end": 658.7,
-      "text": "Double B. Go and cop that. Trust. J. Yeah. Alright. I'm a",
-      "words": [
+        },
         {
           "word": "Double",
           "start": 620.5,
@@ -12011,7 +13469,15 @@
           "word": "B.",
           "start": 620.74,
           "end": 621.22
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 621.58,
+      "end": 629.7,
+      "text": "Go and cop that. Trust. J. Yeah.",
+      "words": [
         {
           "word": "Go",
           "start": 621.58,
@@ -12046,7 +13512,15 @@
           "word": "Yeah.",
           "start": 629.46,
           "end": 629.7
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 631.06,
+      "end": 658.7,
+      "text": "Alright. I'm a",
+      "words": [
         {
           "word": "Alright.",
           "start": 631.06,
@@ -12066,10 +13540,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 174,
       "start": 658.7,
-      "end": 661.22,
-      "text": "bad man. I've never been pranked. When I chat about you better",
+      "end": 660.2,
+      "text": "bad man. I've never been pranked.",
       "words": [
         {
           "word": "bad",
@@ -12100,7 +13573,15 @@
           "word": "pranked.",
           "start": 659.66,
           "end": 660.2
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 660.26,
+      "end": 661.66,
+      "text": "When I chat about you better than man.",
+      "words": [
         {
           "word": "When",
           "start": 660.26,
@@ -12130,16 +13611,7 @@
           "word": "better",
           "start": 661.0,
           "end": 661.22
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 175,
-      "start": 661.22,
-      "end": 664.32,
-      "text": "than man. Little man taking my shredder and crying. Ain't bus one",
-      "words": [
+        },
         {
           "word": "than",
           "start": 661.22,
@@ -12149,7 +13621,15 @@
           "word": "man.",
           "start": 661.44,
           "end": 661.66
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 661.9,
+      "end": 663.52,
+      "text": "Little man taking my shredder and crying.",
+      "words": [
         {
           "word": "Little",
           "start": 661.9,
@@ -12184,7 +13664,15 @@
           "word": "crying.",
           "start": 663.24,
           "end": 663.52
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 663.8,
+      "end": 664.32,
+      "text": "Ain't bus one",
+      "words": [
         {
           "word": "Ain't",
           "start": 663.8,
@@ -12204,10 +13692,9 @@
       "speaker": "JME"
     },
     {
-      "id": 176,
       "start": 664.32,
-      "end": 666.94,
-      "text": "gun shot in my life. But I'm still standing here. You wish",
+      "end": 665.16,
+      "text": "gun shot in my life.",
       "words": [
         {
           "word": "gun",
@@ -12233,7 +13720,15 @@
           "word": "life.",
           "start": 664.92,
           "end": 665.16
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 665.3,
+      "end": 666.94,
+      "text": "But I'm still standing here. You wish",
+      "words": [
         {
           "word": "But",
           "start": 665.3,
@@ -12273,10 +13768,9 @@
       "speaker": "JME"
     },
     {
-      "id": 177,
       "start": 666.94,
-      "end": 669.54,
-      "text": "you was in these night airs. You're there licking off shots in",
+      "end": 668.24,
+      "text": "you was in these night airs.",
       "words": [
         {
           "word": "you",
@@ -12307,7 +13801,15 @@
           "word": "airs.",
           "start": 667.86,
           "end": 668.24
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 668.4,
+      "end": 669.82,
+      "text": "You're there licking off shots in the air.",
+      "words": [
         {
           "word": "You're",
           "start": 668.4,
@@ -12337,16 +13839,7 @@
           "word": "in",
           "start": 669.32,
           "end": 669.54
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 178,
-      "start": 669.54,
-      "end": 672.18,
-      "text": "the air. You've got a silence out and you squeeze. Yeah, but",
-      "words": [
+        },
         {
           "word": "the",
           "start": 669.54,
@@ -12356,7 +13849,15 @@
           "word": "air.",
           "start": 669.66,
           "end": 669.82
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 670.08,
+      "end": 671.44,
+      "text": "You've got a silence out and you squeeze.",
+      "words": [
         {
           "word": "You've",
           "start": 670.08,
@@ -12396,7 +13897,15 @@
           "word": "squeeze.",
           "start": 671.24,
           "end": 671.44
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 671.86,
+      "end": 673.24,
+      "text": "Yeah, but really none of that matters.",
+      "words": [
         {
           "word": "Yeah,",
           "start": 671.86,
@@ -12406,16 +13915,7 @@
           "word": "but",
           "start": 672.0,
           "end": 672.18
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 179,
-      "start": 672.18,
-      "end": 675.38,
-      "text": "really none of that matters. One minute silence for your enemies. One",
-      "words": [
+        },
         {
           "word": "really",
           "start": 672.18,
@@ -12440,7 +13940,15 @@
           "word": "matters.",
           "start": 672.94,
           "end": 673.24
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 673.52,
+      "end": 675.38,
+      "text": "One minute silence for your enemies. One",
+      "words": [
         {
           "word": "One",
           "start": 673.52,
@@ -12480,10 +13988,9 @@
       "speaker": "JME"
     },
     {
-      "id": 180,
       "start": 675.38,
-      "end": 678.36,
-      "text": "minute silence for your bank balance. Whoa. Common sense needs to be",
+      "end": 677.16,
+      "text": "minute silence for your bank balance. Whoa.",
       "words": [
         {
           "word": "minute",
@@ -12519,7 +14026,15 @@
           "word": "Whoa.",
           "start": 676.9,
           "end": 677.16
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 677.44,
+      "end": 678.76,
+      "text": "Common sense needs to be renamed.",
+      "words": [
         {
           "word": "Common",
           "start": 677.44,
@@ -12544,21 +14059,20 @@
           "word": "be",
           "start": 678.18,
           "end": 678.36
+        },
+        {
+          "word": "renamed.",
+          "start": 678.36,
+          "end": 678.76
         }
       ],
       "speaker": "JME"
     },
     {
-      "id": 181,
-      "start": 678.36,
-      "end": 681.42,
-      "text": "renamed. Cause nowadays it's rare. When I was young my mum used",
+      "start": 678.98,
+      "end": 680.12,
+      "text": "Cause nowadays it's rare.",
       "words": [
-        {
-          "word": "renamed.",
-          "start": 678.36,
-          "end": 678.76
-        },
         {
           "word": "Cause",
           "start": 678.98,
@@ -12578,7 +14092,15 @@
           "word": "rare.",
           "start": 679.9,
           "end": 680.12
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 680.34,
+      "end": 681.42,
+      "text": "When I was young my mum used",
+      "words": [
         {
           "word": "When",
           "start": 680.34,
@@ -12618,10 +14140,9 @@
       "speaker": "JME"
     },
     {
-      "id": 182,
       "start": 681.42,
-      "end": 684.36,
-      "text": "to say, Jamie use what's in between your ears. So I did.",
+      "end": 683.56,
+      "text": "to say, Jamie use what's in between your ears.",
       "words": [
         {
           "word": "to",
@@ -12667,7 +14188,15 @@
           "word": "ears.",
           "start": 683.26,
           "end": 683.56
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 683.84,
+      "end": 684.36,
+      "text": "So I did.",
+      "words": [
         {
           "word": "So",
           "start": 683.84,
@@ -12687,10 +14216,9 @@
       "speaker": "JME"
     },
     {
-      "id": 183,
       "start": 684.36,
-      "end": 687.0,
-      "text": "And now I'm here. If I said the same to you, Briss,",
+      "end": 685.3,
+      "text": "And now I'm here.",
       "words": [
         {
           "word": "And",
@@ -12711,7 +14239,15 @@
           "word": "here.",
           "start": 685.04,
           "end": 685.3
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 685.52,
+      "end": 687.0,
+      "text": "If I said the same to you, Briss,",
+      "words": [
         {
           "word": "If",
           "start": 685.52,
@@ -12756,10 +14292,9 @@
       "speaker": "JME"
     },
     {
-      "id": 184,
       "start": 687.1,
-      "end": 689.98,
-      "text": "our future stand there all day. And the rest of you will",
+      "end": 688.68,
+      "text": "our future stand there all day.",
       "words": [
         {
           "word": "our",
@@ -12790,7 +14325,15 @@
           "word": "day.",
           "start": 688.42,
           "end": 688.68
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 688.92,
+      "end": 689.98,
+      "text": "And the rest of you will",
+      "words": [
         {
           "word": "And",
           "start": 688.92,
@@ -12825,10 +14368,9 @@
       "speaker": "JME"
     },
     {
-      "id": 185,
       "start": 689.98,
-      "end": 693.04,
-      "text": "just stare at Syria. So you'll just pull us very back. If",
+      "end": 690.9,
+      "text": "just stare at Syria.",
       "words": [
         {
           "word": "just",
@@ -12849,7 +14391,15 @@
           "word": "Syria.",
           "start": 690.58,
           "end": 690.9
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 690.94,
+      "end": 693.04,
+      "text": "So you'll just pull us very back. If",
+      "words": [
         {
           "word": "So",
           "start": 690.94,
@@ -12894,10 +14444,9 @@
       "speaker": "JME"
     },
     {
-      "id": 186,
       "start": 693.04,
-      "end": 695.42,
-      "text": "you're a hate heart then eff you. Get too close and I'll",
+      "end": 694.3,
+      "text": "you're a hate heart then eff you.",
       "words": [
         {
           "word": "you're",
@@ -12933,7 +14482,15 @@
           "word": "you.",
           "start": 694.06,
           "end": 694.3
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 694.52,
+      "end": 695.42,
+      "text": "Get too close and I'll",
+      "words": [
         {
           "word": "Get",
           "start": 694.52,
@@ -12963,10 +14520,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 187,
       "start": 695.42,
-      "end": 698.28,
-      "text": "hit by you. Front of a hook to the loco too. Bring",
+      "end": 696.02,
+      "text": "hit by you.",
       "words": [
         {
           "word": "hit",
@@ -12982,7 +14538,15 @@
           "word": "you.",
           "start": 695.72,
           "end": 696.02
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 696.38,
+      "end": 698.28,
+      "text": "Front of a hook to the loco too. Bring",
+      "words": [
         {
           "word": "Front",
           "start": 696.38,
@@ -13032,10 +14596,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 188,
       "start": 698.28,
-      "end": 701.16,
-      "text": "your mate in on a loco. You, you and a loco here.",
+      "end": 699.08,
+      "text": "your mate in on a loco.",
       "words": [
         {
           "word": "your",
@@ -13066,7 +14629,15 @@
           "word": "loco.",
           "start": 699.0,
           "end": 699.08
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 699.46,
+      "end": 701.16,
+      "text": "You, you and a loco here.",
+      "words": [
         {
           "word": "You,",
           "start": 699.46,
@@ -13101,10 +14672,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 189,
       "start": 701.62,
-      "end": 703.32,
-      "text": "I don't care what you do. In the gym. Cause if you",
+      "end": 702.4,
+      "text": "I don't care what you do.",
       "words": [
         {
           "word": "I",
@@ -13135,7 +14705,15 @@
           "word": "do.",
           "start": 702.22,
           "end": 702.4
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 702.5,
+      "end": 702.86,
+      "text": "In the gym.",
+      "words": [
         {
           "word": "In",
           "start": 702.5,
@@ -13150,7 +14728,15 @@
           "word": "gym.",
           "start": 702.68,
           "end": 702.86
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 702.98,
+      "end": 703.32,
+      "text": "Cause if you",
+      "words": [
         {
           "word": "Cause",
           "start": 702.98,
@@ -13170,10 +14756,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 190,
       "start": 703.32,
-      "end": 705.86,
-      "text": "do, wait for no time for the pain. I don't bling. I",
+      "end": 704.62,
+      "text": "do, wait for no time for the pain.",
       "words": [
         {
           "word": "do,",
@@ -13214,7 +14799,15 @@
           "word": "pain.",
           "start": 704.36,
           "end": 704.62
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 704.94,
+      "end": 706.3,
+      "text": "I don't bling. I despise.",
+      "words": [
         {
           "word": "I",
           "start": 704.94,
@@ -13234,21 +14827,20 @@
           "word": "I",
           "start": 705.86,
           "end": 705.86
+        },
+        {
+          "word": "despise.",
+          "start": 705.86,
+          "end": 706.3
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 191,
-      "start": 705.86,
-      "end": 709.52,
-      "text": "despise. All they knew when last night. I put food. Yeah, I",
+      "start": 706.58,
+      "end": 707.6,
+      "text": "All they knew when last night.",
       "words": [
-        {
-          "word": "despise.",
-          "start": 705.86,
-          "end": 706.3
-        },
         {
           "word": "All",
           "start": 706.58,
@@ -13278,7 +14870,15 @@
           "word": "night.",
           "start": 707.54,
           "end": 707.6
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 707.7,
+      "end": 709.84,
+      "text": "I put food. Yeah, I sling.",
+      "words": [
         {
           "word": "I",
           "start": 707.7,
@@ -13303,21 +14903,20 @@
           "word": "I",
           "start": 709.46,
           "end": 709.52
+        },
+        {
+          "word": "sling.",
+          "start": 709.52,
+          "end": 709.84
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 192,
-      "start": 709.52,
-      "end": 713.38,
-      "text": "sling. All my sects are up for the ring. Whether you like",
+      "start": 710.12,
+      "end": 711.56,
+      "text": "All my sects are up for the ring.",
       "words": [
-        {
-          "word": "sling.",
-          "start": 709.52,
-          "end": 709.84
-        },
         {
           "word": "All",
           "start": 710.12,
@@ -13357,7 +14956,15 @@
           "word": "ring.",
           "start": 711.38,
           "end": 711.56
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 712.6,
+      "end": 713.38,
+      "text": "Whether you like",
+      "words": [
         {
           "word": "Whether",
           "start": 712.6,
@@ -13377,10 +14984,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 193,
       "start": 713.38,
-      "end": 717.08,
-      "text": "it or not, this was other. Trust. They got skipped off. Don't",
+      "end": 715.18,
+      "text": "it or not, this was other. Trust.",
       "words": [
         {
           "word": "it",
@@ -13416,7 +15022,15 @@
           "word": "Trust.",
           "start": 715.0,
           "end": 715.18
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 715.76,
+      "end": 718.46,
+      "text": "They got skipped off. Don't know. Classical.",
+      "words": [
         {
           "word": "They",
           "start": 715.76,
@@ -13441,16 +15055,7 @@
           "word": "Don't",
           "start": 716.94,
           "end": 717.08
-        }
-      ],
-      "speaker": "Footsie"
-    },
-    {
-      "id": 194,
-      "start": 717.08,
-      "end": 726.38,
-      "text": "know. Classical. Oh, that's a skip top. Okay then. Very spec. If",
-      "words": [
+        },
         {
           "word": "know.",
           "start": 717.08,
@@ -13460,7 +15065,15 @@
           "word": "Classical.",
           "start": 718.1,
           "end": 718.46
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 718.76,
+      "end": 725.82,
+      "text": "Oh, that's a skip top. Okay then. Very spec.",
+      "words": [
         {
           "word": "Oh,",
           "start": 718.76,
@@ -13505,21 +15118,20 @@
           "word": "spec.",
           "start": 725.46,
           "end": 725.82
-        },
-        {
-          "word": "If",
-          "start": 726.26,
-          "end": 726.38
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 195,
-      "start": 726.38,
-      "end": 728.76,
-      "text": "you're a hate heart then eff you. Get too close and I'll",
+      "start": 726.26,
+      "end": 727.68,
+      "text": "If you're a hate heart then eff you.",
       "words": [
+        {
+          "word": "If",
+          "start": 726.26,
+          "end": 726.38
+        },
         {
           "word": "you're",
           "start": 726.38,
@@ -13554,7 +15166,15 @@
           "word": "you.",
           "start": 727.44,
           "end": 727.68
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 727.98,
+      "end": 728.76,
+      "text": "Get too close and I'll",
+      "words": [
         {
           "word": "Get",
           "start": 727.98,
@@ -13584,10 +15204,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 196,
       "start": 728.76,
-      "end": 731.54,
-      "text": "hit by you. Front of a hook to the loco too. Bring",
+      "end": 729.3,
+      "text": "hit by you.",
       "words": [
         {
           "word": "hit",
@@ -13603,7 +15222,15 @@
           "word": "you.",
           "start": 729.04,
           "end": 729.3
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 729.62,
+      "end": 731.54,
+      "text": "Front of a hook to the loco too. Bring",
+      "words": [
         {
           "word": "Front",
           "start": 729.62,
@@ -13653,10 +15280,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 197,
       "start": 731.54,
-      "end": 734.42,
-      "text": "your mate in on a loco. You, you and a loco here.",
+      "end": 732.4,
+      "text": "your mate in on a loco.",
       "words": [
         {
           "word": "your",
@@ -13687,7 +15313,15 @@
           "word": "loco.",
           "start": 732.28,
           "end": 732.4
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 732.76,
+      "end": 734.42,
+      "text": "You, you and a loco here.",
+      "words": [
         {
           "word": "You,",
           "start": 732.76,
@@ -13722,10 +15356,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 198,
       "start": 734.84,
-      "end": 736.6,
-      "text": "I don't care what you do. In the gym. Cause if you",
+      "end": 735.72,
+      "text": "I don't care what you do.",
       "words": [
         {
           "word": "I",
@@ -13756,7 +15389,15 @@
           "word": "do.",
           "start": 735.54,
           "end": 735.72
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 735.82,
+      "end": 736.16,
+      "text": "In the gym.",
+      "words": [
         {
           "word": "In",
           "start": 735.82,
@@ -13771,7 +15412,15 @@
           "word": "gym.",
           "start": 735.98,
           "end": 736.16
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 736.28,
+      "end": 736.6,
+      "text": "Cause if you",
+      "words": [
         {
           "word": "Cause",
           "start": 736.28,
@@ -13791,10 +15440,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 199,
       "start": 736.6,
-      "end": 739.16,
-      "text": "do, wait for no time for the pain. I don't bling. I",
+      "end": 737.94,
+      "text": "do, wait for no time for the pain.",
       "words": [
         {
           "word": "do,",
@@ -13835,7 +15483,15 @@
           "word": "pain.",
           "start": 737.68,
           "end": 737.94
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 738.26,
+      "end": 739.64,
+      "text": "I don't bling. I despise.",
+      "words": [
         {
           "word": "I",
           "start": 738.26,
@@ -13855,21 +15511,20 @@
           "word": "I",
           "start": 739.16,
           "end": 739.16
+        },
+        {
+          "word": "despise.",
+          "start": 739.16,
+          "end": 739.64
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 200,
-      "start": 739.16,
-      "end": 742.8,
-      "text": "despise. All they knew when last night. I put food. Yeah, I",
+      "start": 739.64,
+      "end": 741.04,
+      "text": "All they knew when last night.",
       "words": [
-        {
-          "word": "despise.",
-          "start": 739.16,
-          "end": 739.64
-        },
         {
           "word": "All",
           "start": 739.64,
@@ -13899,7 +15554,15 @@
           "word": "night.",
           "start": 740.86,
           "end": 741.04
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 741.42,
+      "end": 743.16,
+      "text": "I put food. Yeah, I sling.",
+      "words": [
         {
           "word": "I",
           "start": 741.42,
@@ -13924,21 +15587,20 @@
           "word": "I",
           "start": 742.66,
           "end": 742.8
+        },
+        {
+          "word": "sling.",
+          "start": 742.8,
+          "end": 743.16
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 201,
-      "start": 742.8,
-      "end": 745.4,
-      "text": "sling. All my sects are up for the ring. I want to",
+      "start": 743.4,
+      "end": 744.82,
+      "text": "All my sects are up for the ring.",
       "words": [
-        {
-          "word": "sling.",
-          "start": 742.8,
-          "end": 743.16
-        },
         {
           "word": "All",
           "start": 743.4,
@@ -13978,7 +15640,15 @@
           "word": "ring.",
           "start": 744.54,
           "end": 744.82
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 745.16,
+      "end": 745.4,
+      "text": "I want to",
+      "words": [
         {
           "word": "I",
           "start": 745.16,
@@ -13998,10 +15668,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 202,
       "start": 745.4,
-      "end": 748.22,
-      "text": "get through with no hold ups. I ain't got time for throwing",
+      "end": 746.92,
+      "text": "get through with no hold ups.",
       "words": [
         {
           "word": "get",
@@ -14032,7 +15701,15 @@
           "word": "ups.",
           "start": 746.52,
           "end": 746.92
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 747.14,
+      "end": 748.56,
+      "text": "I ain't got time for throwing up.",
+      "words": [
         {
           "word": "I",
           "start": 747.14,
@@ -14062,21 +15739,20 @@
           "word": "throwing",
           "start": 747.9,
           "end": 748.22
+        },
+        {
+          "word": "up.",
+          "start": 748.22,
+          "end": 748.56
         }
       ],
       "speaker": "Footsie"
     },
     {
-      "id": 203,
-      "start": 748.22,
-      "end": 750.7,
-      "text": "up. So now me I'm going through. Cause I'm gonna drop one",
+      "start": 748.74,
+      "end": 749.82,
+      "text": "So now me I'm going through.",
       "words": [
-        {
-          "word": "up.",
-          "start": 748.22,
-          "end": 748.56
-        },
         {
           "word": "So",
           "start": 748.74,
@@ -14106,7 +15782,15 @@
           "word": "through.",
           "start": 749.46,
           "end": 749.82
-        },
+        }
+      ],
+      "speaker": "Footsie"
+    },
+    {
+      "start": 749.98,
+      "end": 750.7,
+      "text": "Cause I'm gonna drop one",
+      "words": [
         {
           "word": "Cause",
           "start": 749.98,
@@ -14136,10 +15820,9 @@
       "speaker": "Footsie"
     },
     {
-      "id": 204,
       "start": 750.7,
-      "end": 753.38,
-      "text": "album in two. Call me. Do you like it or do you",
+      "end": 752.38,
+      "text": "album in two. Call me.",
       "words": [
         {
           "word": "album",
@@ -14165,7 +15848,15 @@
           "word": "me.",
           "start": 752.24,
           "end": 752.38
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 752.4,
+      "end": 753.38,
+      "text": "Do you like it or do you",
+      "words": [
         {
           "word": "Do",
           "start": 752.4,
@@ -14205,10 +15896,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 205,
       "start": 753.38,
-      "end": 757.1,
-      "text": "like it or not? I smell like the number one. The number",
+      "end": 755.02,
+      "text": "like it or not?",
       "words": [
         {
           "word": "like",
@@ -14229,7 +15919,15 @@
           "word": "not?",
           "start": 754.78,
           "end": 755.02
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 755.28,
+      "end": 757.4,
+      "text": "I smell like the number one. The number one.",
+      "words": [
         {
           "word": "I",
           "start": 755.28,
@@ -14269,21 +15967,20 @@
           "word": "number",
           "start": 756.88,
           "end": 757.1
+        },
+        {
+          "word": "one.",
+          "start": 757.1,
+          "end": 757.4
         }
       ],
       "speaker": "D Double E"
     },
     {
-      "id": 206,
-      "start": 757.1,
-      "end": 760.08,
-      "text": "one. The number one. I say, Do you like it or do",
+      "start": 757.52,
+      "end": 758.3,
+      "text": "The number one.",
       "words": [
-        {
-          "word": "one.",
-          "start": 757.1,
-          "end": 757.4
-        },
         {
           "word": "The",
           "start": 757.52,
@@ -14298,7 +15995,15 @@
           "word": "one.",
           "start": 757.96,
           "end": 758.3
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 758.32,
+      "end": 760.08,
+      "text": "I say, Do you like it or do",
+      "words": [
         {
           "word": "I",
           "start": 758.32,
@@ -14343,10 +16048,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 207,
       "start": 760.08,
-      "end": 763.68,
-      "text": "you like it or not? I smell like the number one. The",
+      "end": 761.84,
+      "text": "you like it or not?",
       "words": [
         {
           "word": "you",
@@ -14372,7 +16076,15 @@
           "word": "not?",
           "start": 761.6,
           "end": 761.84
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 762.16,
+      "end": 764.22,
+      "text": "I smell like the number one. The number one.",
+      "words": [
         {
           "word": "I",
           "start": 762.16,
@@ -14407,16 +16119,7 @@
           "word": "The",
           "start": 763.52,
           "end": 763.68
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 208,
-      "start": 763.68,
-      "end": 766.44,
-      "text": "number one. The number one. The number one. Two moves in a",
-      "words": [
+        },
         {
           "word": "number",
           "start": 763.68,
@@ -14426,7 +16129,15 @@
           "word": "one.",
           "start": 763.9,
           "end": 764.22
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 764.34,
+      "end": 764.52,
+      "text": "The number one.",
+      "words": [
         {
           "word": "The",
           "start": 764.34,
@@ -14441,7 +16152,15 @@
           "word": "one.",
           "start": 764.52,
           "end": 764.52
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 764.52,
+      "end": 765.02,
+      "text": "The number one.",
+      "words": [
         {
           "word": "The",
           "start": 764.52,
@@ -14456,7 +16175,15 @@
           "word": "one.",
           "start": 764.78,
           "end": 765.02
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 765.54,
+      "end": 766.72,
+      "text": "Two moves in a bucket.",
+      "words": [
         {
           "word": "Two",
           "start": 765.54,
@@ -14476,21 +16203,20 @@
           "word": "a",
           "start": 766.36,
           "end": 766.44
+        },
+        {
+          "word": "bucket.",
+          "start": 766.44,
+          "end": 766.72
         }
       ],
       "speaker": "D Double E"
     },
     {
-      "id": 209,
-      "start": 766.44,
-      "end": 769.54,
-      "text": "bucket. Don't even know man. I'm gonna chuck it. Is it because",
+      "start": 767.26,
+      "end": 768.06,
+      "text": "Don't even know man.",
       "words": [
-        {
-          "word": "bucket.",
-          "start": 766.44,
-          "end": 766.72
-        },
         {
           "word": "Don't",
           "start": 767.26,
@@ -14510,7 +16236,15 @@
           "word": "man.",
           "start": 767.9,
           "end": 768.06
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 768.14,
+      "end": 768.96,
+      "text": "I'm gonna chuck it.",
+      "words": [
         {
           "word": "I'm",
           "start": 768.14,
@@ -14530,7 +16264,15 @@
           "word": "it.",
           "start": 768.74,
           "end": 768.96
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 768.96,
+      "end": 769.54,
+      "text": "Is it because",
+      "words": [
         {
           "word": "Is",
           "start": 768.96,
@@ -14550,10 +16292,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 210,
       "start": 769.54,
-      "end": 771.92,
-      "text": "your crew's not big yet? Is it because you ain't done one",
+      "end": 770.66,
+      "text": "your crew's not big yet?",
       "words": [
         {
           "word": "your",
@@ -14579,7 +16320,15 @@
           "word": "yet?",
           "start": 770.46,
           "end": 770.66
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 770.72,
+      "end": 772.36,
+      "text": "Is it because you ain't done one kick yet?",
+      "words": [
         {
           "word": "Is",
           "start": 770.72,
@@ -14614,16 +16363,7 @@
           "word": "one",
           "start": 771.7,
           "end": 771.92
-        }
-      ],
-      "speaker": "D Double E"
-    },
-    {
-      "id": 211,
-      "start": 771.92,
-      "end": 774.68,
-      "text": "kick yet? Is it because this music like the Usman running up",
-      "words": [
+        },
         {
           "word": "kick",
           "start": 771.92,
@@ -14633,7 +16373,15 @@
           "word": "yet?",
           "start": 772.14,
           "end": 772.36
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 772.6,
+      "end": 773.94,
+      "text": "Is it because this music like the",
+      "words": [
         {
           "word": "Is",
           "start": 772.6,
@@ -14668,7 +16416,15 @@
           "word": "the",
           "start": 773.78,
           "end": 773.94
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 773.94,
+      "end": 774.68,
+      "text": "Usman running up",
+      "words": [
         {
           "word": "Usman",
           "start": 773.94,
@@ -14688,10 +16444,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 212,
       "start": 774.68,
-      "end": 776.72,
-      "text": "and you're going from watch man to put something up because you're",
+      "end": 776.16,
+      "text": "and you're going from watch man to put something",
       "words": [
         {
           "word": "and",
@@ -14737,7 +16492,15 @@
           "word": "something",
           "start": 775.94,
           "end": 776.16
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 776.16,
+      "end": 776.72,
+      "text": "up because you're",
+      "words": [
         {
           "word": "up",
           "start": 776.16,
@@ -14757,10 +16520,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 213,
       "start": 776.72,
-      "end": 779.2,
-      "text": "going in like you're not feeling man. It is the DJs and",
+      "end": 778.2,
+      "text": "going in like you're not feeling man.",
       "words": [
         {
           "word": "going",
@@ -14796,7 +16558,15 @@
           "word": "man.",
           "start": 777.88,
           "end": 778.2
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 778.26,
+      "end": 779.2,
+      "text": "It is the DJs and",
+      "words": [
         {
           "word": "It",
           "start": 778.26,
@@ -14826,10 +16596,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 214,
       "start": 779.2,
-      "end": 781.64,
-      "text": "the wheelie man. I got sweat coming up from the ceiling. I",
+      "end": 779.78,
+      "text": "the wheelie man.",
       "words": [
         {
           "word": "the",
@@ -14845,7 +16614,15 @@
           "word": "man.",
           "start": 779.64,
           "end": 779.78
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 779.9,
+      "end": 781.64,
+      "text": "I got sweat coming up from the ceiling. I",
+      "words": [
         {
           "word": "I",
           "start": 779.9,
@@ -14895,10 +16672,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 215,
       "start": 781.64,
-      "end": 784.78,
-      "text": "thought you're going from space and feeling. Too much foundation. Don't even",
+      "end": 782.94,
+      "text": "thought you're going from space and feeling.",
       "words": [
         {
           "word": "thought",
@@ -14934,7 +16710,15 @@
           "word": "feeling.",
           "start": 782.62,
           "end": 782.94
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 783.36,
+      "end": 784.78,
+      "text": "Too much foundation. Don't even",
+      "words": [
         {
           "word": "Too",
           "start": 783.36,
@@ -14964,10 +16748,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 216,
       "start": 784.78,
-      "end": 787.64,
-      "text": "know the Usman foundation. Man, when I slew me on radio station,",
+      "end": 785.72,
+      "text": "know the Usman foundation.",
       "words": [
         {
           "word": "know",
@@ -14988,7 +16771,15 @@
           "word": "foundation.",
           "start": 785.34,
           "end": 785.72
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 786.28,
+      "end": 787.64,
+      "text": "Man, when I slew me on radio station,",
+      "words": [
         {
           "word": "Man,",
           "start": 786.28,
@@ -15033,10 +16824,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 217,
       "start": 787.7,
-      "end": 789.98,
-      "text": "the two boots fit in bars in an oven nation. D .W",
+      "end": 789.04,
+      "text": "the two boots fit in bars in an oven",
       "words": [
         {
           "word": "the",
@@ -15082,7 +16872,15 @@
           "word": "oven",
           "start": 788.94,
           "end": 789.04
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 789.04,
+      "end": 789.98,
+      "text": "nation. D .W",
+      "words": [
         {
           "word": "nation.",
           "start": 789.04,
@@ -15102,10 +16900,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 218,
       "start": 789.98,
-      "end": 799.36,
-      "text": ".F .T. combination. Around the world with you the rotation. Fringe. I'm",
+      "end": 791.06,
+      "text": ".F .T. combination.",
       "words": [
         {
           "word": ".F",
@@ -15121,7 +16918,15 @@
           "word": "combination.",
           "start": 790.7,
           "end": 791.06
-        },
+        }
+      ],
+      "speaker": "D Double E"
+    },
+    {
+      "start": 791.32,
+      "end": 799.36,
+      "text": "Around the world with you the rotation. Fringe. I'm",
+      "words": [
         {
           "word": "Around",
           "start": 791.32,
@@ -15171,10 +16976,9 @@
       "speaker": "D Double E"
     },
     {
-      "id": 219,
       "start": 799.36,
-      "end": 802.32,
-      "text": "the first to quench. Trust. That's your over that fin. Next time",
+      "end": 800.38,
+      "text": "the first to quench. Trust.",
       "words": [
         {
           "word": "the",
@@ -15200,7 +17004,15 @@
           "word": "Trust.",
           "start": 800.08,
           "end": 800.38
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 800.64,
+      "end": 802.32,
+      "text": "That's your over that fin. Next time",
+      "words": [
         {
           "word": "That's",
           "start": 800.64,
@@ -15240,10 +17052,9 @@
       "speaker": "JME"
     },
     {
-      "id": 220,
       "start": 802.32,
-      "end": 805.8,
-      "text": "think about consequences. If you had any sense you would not ask.",
+      "end": 803.16,
+      "text": "think about consequences.",
       "words": [
         {
           "word": "think",
@@ -15259,7 +17070,15 @@
           "word": "consequences.",
           "start": 802.72,
           "end": 803.16
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 804.28,
+      "end": 805.8,
+      "text": "If you had any sense you would not ask.",
+      "words": [
         {
           "word": "If",
           "start": 804.28,
@@ -15309,10 +17128,9 @@
       "speaker": "JME"
     },
     {
-      "id": 221,
       "start": 805.94,
-      "end": 809.28,
-      "text": "Jamey for 10 pence. See you later. Trust me. See you. That",
+      "end": 806.78,
+      "text": "Jamey for 10 pence.",
       "words": [
         {
           "word": "Jamey",
@@ -15333,7 +17151,15 @@
           "word": "pence.",
           "start": 806.5,
           "end": 806.78
-        },
+        }
+      ],
+      "speaker": "SPEAKER_06"
+    },
+    {
+      "start": 807.12,
+      "end": 809.28,
+      "text": "See you later. Trust me. See you. That",
+      "words": [
         {
           "word": "See",
           "start": 807.12,
@@ -15378,10 +17204,9 @@
       "speaker": "SPEAKER_06"
     },
     {
-      "id": 222,
       "start": 809.28,
-      "end": 811.84,
-      "text": "was in my head bro. Nothing else. I swear I'm looking down",
+      "end": 810.34,
+      "text": "was in my head bro. Nothing else.",
       "words": [
         {
           "word": "was",
@@ -15417,7 +17242,15 @@
           "word": "else.",
           "start": 810.08,
           "end": 810.34
-        },
+        }
+      ],
+      "speaker": "SPEAKER_06"
+    },
+    {
+      "start": 810.84,
+      "end": 812.04,
+      "text": "I swear I'm looking down there.",
+      "words": [
         {
           "word": "I",
           "start": 810.84,
@@ -15442,21 +17275,20 @@
           "word": "down",
           "start": 811.62,
           "end": 811.84
+        },
+        {
+          "word": "there.",
+          "start": 811.84,
+          "end": 812.04
         }
       ],
       "speaker": "SPEAKER_06"
     },
     {
-      "id": 223,
-      "start": 811.84,
-      "end": 817.48,
-      "text": "there. Nothing else bro. Had to be that. Sick lyrics. Words and",
+      "start": 812.48,
+      "end": 813.34,
+      "text": "Nothing else bro.",
       "words": [
-        {
-          "word": "there.",
-          "start": 811.84,
-          "end": 812.04
-        },
         {
           "word": "Nothing",
           "start": 812.48,
@@ -15471,7 +17303,15 @@
           "word": "bro.",
           "start": 813.12,
           "end": 813.34
-        },
+        }
+      ],
+      "speaker": "SPEAKER_06"
+    },
+    {
+      "start": 813.9,
+      "end": 817.48,
+      "text": "Had to be that. Sick lyrics. Words and",
+      "words": [
         {
           "word": "Had",
           "start": 813.9,
@@ -15516,10 +17356,9 @@
       "speaker": "SPEAKER_06"
     },
     {
-      "id": 224,
       "start": 817.48,
-      "end": 820.8,
-      "text": "verbs. Cosmo herbs. Outside parked up next to the curb. I've got",
+      "end": 818.56,
+      "text": "verbs. Cosmo herbs.",
       "words": [
         {
           "word": "verbs.",
@@ -15535,7 +17374,15 @@
           "word": "herbs.",
           "start": 818.24,
           "end": 818.56
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 818.86,
+      "end": 820.8,
+      "text": "Outside parked up next to the curb. I've got",
+      "words": [
         {
           "word": "Outside",
           "start": 818.86,
@@ -15585,10 +17432,9 @@
       "speaker": "JME"
     },
     {
-      "id": 225,
       "start": 820.8,
-      "end": 854.12,
-      "text": "a map that soup tops herbs. Fools. That was a scout opinion.",
+      "end": 822.5,
+      "text": "a map that soup tops herbs. Fools.",
       "words": [
         {
           "word": "a",
@@ -15624,7 +17470,15 @@
           "word": "Fools.",
           "start": 822.28,
           "end": 822.5
-        },
+        }
+      ],
+      "speaker": "JME"
+    },
+    {
+      "start": 852.7,
+      "end": 854.12,
+      "text": "That was a scout opinion.",
+      "words": [
         {
           "word": "That",
           "start": 852.7,
@@ -15654,10 +17508,9 @@
       "speaker": "JME"
     },
     {
-      "id": 226,
       "start": 854.32,
-      "end": 857.22,
-      "text": "Of course. I can't ever have D .W .E. and Jamey in",
+      "end": 856.64,
+      "text": "Of course. I can't ever have D .W .E.",
       "words": [
         {
           "word": "Of",
@@ -15703,7 +17556,15 @@
           "word": ".E.",
           "start": 856.46,
           "end": 856.64
-        },
+        }
+      ],
+      "speaker": "SPEAKER_02"
+    },
+    {
+      "start": 856.72,
+      "end": 857.54,
+      "text": "and Jamey in the studio.",
+      "words": [
         {
           "word": "and",
           "start": 856.72,
@@ -15718,16 +17579,7 @@
           "word": "in",
           "start": 857.16,
           "end": 857.22
-        }
-      ],
-      "speaker": "SPEAKER_02"
-    },
-    {
-      "id": 227,
-      "start": 857.22,
-      "end": 861.72,
-      "text": "the studio. We don't get the foundation records. Played never that. It's",
-      "words": [
+        },
         {
           "word": "the",
           "start": 857.22,
@@ -15737,7 +17589,15 @@
           "word": "studio.",
           "start": 857.3,
           "end": 857.54
-        },
+        }
+      ],
+      "speaker": "SPEAKER_02"
+    },
+    {
+      "start": 857.72,
+      "end": 859.54,
+      "text": "We don't get the foundation records.",
+      "words": [
         {
           "word": "We",
           "start": 857.72,
@@ -15767,7 +17627,15 @@
           "word": "records.",
           "start": 858.96,
           "end": 859.54
-        },
+        }
+      ],
+      "speaker": "SPEAKER_02"
+    },
+    {
+      "start": 859.92,
+      "end": 861.72,
+      "text": "Played never that. It's",
+      "words": [
         {
           "word": "Played",
           "start": 859.92,
@@ -15792,10 +17660,9 @@
       "speaker": "SPEAKER_02"
     },
     {
-      "id": 228,
       "start": 861.72,
-      "end": 863.42,
-      "text": "come to the end of the show. I've got five seconds. So",
+      "end": 862.44,
+      "text": "come to the end of the show.",
       "words": [
         {
           "word": "come",
@@ -15831,7 +17698,15 @@
           "word": "show.",
           "start": 862.26,
           "end": 862.44
-        },
+        }
+      ],
+      "speaker": "Logan Sama"
+    },
+    {
+      "start": 862.52,
+      "end": 863.42,
+      "text": "I've got five seconds. So",
+      "words": [
         {
           "word": "I've",
           "start": 862.52,
@@ -15861,10 +17736,9 @@
       "speaker": "Logan Sama"
     },
     {
-      "id": 229,
       "start": 863.42,
-      "end": 866.16,
-      "text": "back agrees out now. Blames out now. I'll be back next Monday.",
+      "end": 864.34,
+      "text": "back agrees out now.",
       "words": [
         {
           "word": "back",
@@ -15885,7 +17759,15 @@
           "word": "now.",
           "start": 864.14,
           "end": 864.34
-        },
+        }
+      ],
+      "speaker": "Logan Sama"
+    },
+    {
+      "start": 864.46,
+      "end": 865.16,
+      "text": "Blames out now.",
+      "words": [
         {
           "word": "Blames",
           "start": 864.46,
@@ -15900,7 +17782,15 @@
           "word": "now.",
           "start": 864.96,
           "end": 865.16
-        },
+        }
+      ],
+      "speaker": "Logan Sama"
+    },
+    {
+      "start": 865.28,
+      "end": 866.16,
+      "text": "I'll be back next Monday.",
+      "words": [
         {
           "word": "I'll",
           "start": 865.28,

--- a/data/ARCHIVE_003_data.json
+++ b/data/ARCHIVE_003_data.json
@@ -1,9 +1,9 @@
 {
   "title": "KISS FM 2006 Logan Sama & Boy Better Know Crew",
-  "duration": 1580.00,
+  "duration": 1580.0,
   "instrumentals": [
     {
-      "start": 0.00,
+      "start": 0.0,
       "end": 36.85,
       "title": "PLACEHOLDER 1",
       "artist": "TODO"
@@ -208,8 +208,8 @@
     {
       "id": 4,
       "start": 7.33,
-      "end": 10.91,
-      "text": "got the full Boy Better Know crew inside the",
+      "end": 9.85,
+      "text": "got the full Boy Better Know crew",
       "words": [
         {
           "word": "got",
@@ -252,7 +252,16 @@
           "start": 9.47,
           "end": 9.85,
           "probability": 0.8809945583343506
-        },
+        }
+      ],
+      "speaker": "Logan Sama"
+    },
+    {
+      "id": 5,
+      "start": 9.85,
+      "end": 11.27,
+      "text": "inside the studio.",
+      "words": [
         {
           "word": "inside",
           "start": 9.85,
@@ -264,16 +273,7 @@
           "start": 10.73,
           "end": 10.91,
           "probability": 0.976901113986969
-        }
-      ],
-      "speaker": "Logan Sama"
-    },
-    {
-      "id": 5,
-      "start": 10.91,
-      "end": 11.27,
-      "text": "studio.",
-      "words": [
+        },
         {
           "word": "studio.",
           "start": 10.91,
@@ -497,10 +497,10 @@
       "speaker": "JME"
     },
     {
-      "id": 11,
+      "id": 12,
       "start": 24.45,
-      "end": 25.19,
-      "text": "that time",
+      "end": 27.99,
+      "text": "that time Yo Yo You better know what's crackin'",
       "words": [
         {
           "word": "that",
@@ -513,16 +513,7 @@
           "start": 24.67,
           "end": 25.19,
           "probability": 0.9887079000473022
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 12,
-      "start": 25.19,
-      "end": 27.99,
-      "text": "Yo Yo You better know what's crackin'",
-      "words": [
+        },
         {
           "word": "Yo",
           "start": 25.19,
@@ -871,8 +862,8 @@
     {
       "id": 19,
       "start": 36.63,
-      "end": 38.37,
-      "text": "Boy better know if Boy better knows in a",
+      "end": 38.07,
+      "text": "Boy better know if Boy better knows",
       "words": [
         {
           "word": "Boy",
@@ -915,7 +906,16 @@
           "start": 37.87,
           "end": 38.07,
           "probability": 0.6799355149269104
-        },
+        }
+      ],
+      "speaker": "Jammer"
+    },
+    {
+      "id": 20,
+      "start": 38.07,
+      "end": 38.45,
+      "text": "in a bill",
+      "words": [
         {
           "word": "in",
           "start": 38.07,
@@ -927,16 +927,7 @@
           "start": 38.23,
           "end": 38.37,
           "probability": 0.601111114025116
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 20,
-      "start": 38.37,
-      "end": 38.45,
-      "text": "bill",
-      "words": [
+        },
         {
           "word": "bill",
           "start": 38.37,
@@ -1057,8 +1048,8 @@
     {
       "id": 23,
       "start": 41.39,
-      "end": 43.05,
-      "text": "And if the record ain't broke then I'm breakin'",
+      "end": 42.45,
+      "text": "And if the record ain't broke then",
       "words": [
         {
           "word": "And",
@@ -1101,7 +1092,16 @@
           "start": 42.31,
           "end": 42.45,
           "probability": 0.8141984343528748
-        },
+        }
+      ],
+      "speaker": "Jammer"
+    },
+    {
+      "id": 24,
+      "start": 42.45,
+      "end": 43.13,
+      "text": "I'm breakin' that",
+      "words": [
         {
           "word": "I'm",
           "start": 42.45,
@@ -1113,16 +1113,7 @@
           "start": 42.61,
           "end": 43.05,
           "probability": 0.9539828896522522
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 24,
-      "start": 43.07,
-      "end": 43.13,
-      "text": "that",
-      "words": [
+        },
         {
           "word": "that",
           "start": 43.07,
@@ -1135,8 +1126,8 @@
     {
       "id": 25,
       "start": 43.13,
-      "end": 44.79,
-      "text": "Don't care what you're makin' back I just want",
+      "end": 44.65,
+      "text": "Don't care what you're makin' back I just",
       "words": [
         {
           "word": "Don't",
@@ -1185,22 +1176,22 @@
           "start": 44.47,
           "end": 44.65,
           "probability": 0.9793175458908081
-        },
-        {
-          "word": "want",
-          "start": 44.65,
-          "end": 44.79,
-          "probability": 0.8718274831771851
         }
       ],
       "speaker": "Jammer"
     },
     {
       "id": 26,
-      "start": 44.79,
+      "start": 44.65,
       "end": 45.37,
-      "text": "what's mine",
+      "text": "want what's mine",
       "words": [
+        {
+          "word": "want",
+          "start": 44.65,
+          "end": 44.79,
+          "probability": 0.8718274831771851
+        },
         {
           "word": "what's",
           "start": 44.79,
@@ -1282,8 +1273,8 @@
     {
       "id": 28,
       "start": 48.33,
-      "end": 50.25,
-      "text": "Make a man happy like he's takin' crack I",
+      "end": 49.95,
+      "text": "Make a man happy like he's takin' crack",
       "words": [
         {
           "word": "Make",
@@ -1332,22 +1323,22 @@
           "start": 49.85,
           "end": 49.95,
           "probability": 0.9843093156814575
-        },
-        {
-          "word": "I",
-          "start": 49.95,
-          "end": 50.25,
-          "probability": 0.9559065699577332
         }
       ],
       "speaker": "Jammer"
     },
     {
       "id": 29,
-      "start": 50.25,
+      "start": 49.95,
       "end": 50.79,
-      "text": "do music",
+      "text": "I do music",
       "words": [
+        {
+          "word": "I",
+          "start": 49.95,
+          "end": 50.25,
+          "probability": 0.9559065699577332
+        },
         {
           "word": "do",
           "start": 50.25,
@@ -1462,8 +1453,8 @@
     {
       "id": 32,
       "start": 53.43,
-      "end": 56.29,
-      "text": "I got to make this clear Big Frisco totally",
+      "end": 55.45,
+      "text": "I got to make this clear Big",
       "words": [
         {
           "word": "I",
@@ -1506,7 +1497,16 @@
           "start": 55.17,
           "end": 55.45,
           "probability": 0.8785129189491272
-        },
+        }
+      ],
+      "speaker": "Frisco"
+    },
+    {
+      "id": 33,
+      "start": 55.45,
+      "end": 56.83,
+      "text": "Frisco totally unruly",
+      "words": [
         {
           "word": "Frisco",
           "start": 55.45,
@@ -1518,16 +1518,7 @@
           "start": 55.75,
           "end": 56.29,
           "probability": 0.5458931922912598
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 33,
-      "start": 56.29,
-      "end": 56.83,
-      "text": "unruly",
-      "words": [
+        },
         {
           "word": "unruly",
           "start": 56.29,
@@ -1648,8 +1639,8 @@
     {
       "id": 36,
       "start": 60.47,
-      "end": 63.31,
-      "text": "And even though everything's nice now Still got a",
+      "end": 63.19,
+      "text": "And even though everything's nice now Still got",
       "words": [
         {
           "word": "And",
@@ -1698,22 +1689,22 @@
           "start": 62.99,
           "end": 63.19,
           "probability": 0.907217264175415
-        },
-        {
-          "word": "a",
-          "start": 63.19,
-          "end": 63.31,
-          "probability": 0.8355207443237305
         }
       ],
       "speaker": "Frisco"
     },
     {
       "id": 37,
-      "start": 63.31,
+      "start": 63.19,
       "end": 63.71,
-      "text": "mind now",
+      "text": "a mind now",
       "words": [
+        {
+          "word": "a",
+          "start": 63.19,
+          "end": 63.31,
+          "probability": 0.8355207443237305
+        },
         {
           "word": "mind",
           "start": 63.31,
@@ -1981,8 +1972,8 @@
     {
       "id": 43,
       "start": 70.65,
-      "end": 73.71,
-      "text": "We're never gonna be done with it Run with",
+      "end": 73.13,
+      "text": "We're never gonna be done with it",
       "words": [
         {
           "word": "We're",
@@ -2025,7 +2016,16 @@
           "start": 72.05,
           "end": 73.13,
           "probability": 0.9969618916511536
-        },
+        }
+      ],
+      "speaker": "Frisco"
+    },
+    {
+      "id": 44,
+      "start": 73.13,
+      "end": 73.93,
+      "text": "Run with it",
+      "words": [
         {
           "word": "Run",
           "start": 73.13,
@@ -2037,16 +2037,7 @@
           "start": 73.49,
           "end": 73.71,
           "probability": 0.9810839295387268
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 44,
-      "start": 73.71,
-      "end": 73.93,
-      "text": "it",
-      "words": [
+        },
         {
           "word": "it",
           "start": 73.71,
@@ -2896,8 +2887,8 @@
     {
       "id": 60,
       "start": 98.91,
-      "end": 100.31,
-      "text": "boy He better know it's not gonna be a",
+      "end": 100.15,
+      "text": "boy He better know it's not gonna be",
       "words": [
         {
           "word": "boy",
@@ -2946,22 +2937,22 @@
           "start": 99.95,
           "end": 100.15,
           "probability": 0.9904246926307678
-        },
-        {
-          "word": "a",
-          "start": 100.15,
-          "end": 100.31,
-          "probability": 0.9916919469833374
         }
       ],
       "speaker": "Skepta"
     },
     {
       "id": 61,
-      "start": 100.31,
+      "start": 100.15,
       "end": 100.83,
-      "text": "re -ball",
+      "text": "a re -ball",
       "words": [
+        {
+          "word": "a",
+          "start": 100.15,
+          "end": 100.31,
+          "probability": 0.9916919469833374
+        },
         {
           "word": "re",
           "start": 100.31,
@@ -2980,8 +2971,8 @@
     {
       "id": 62,
       "start": 100.83,
-      "end": 103.55,
-      "text": "99 % it's an auto So you better respect",
+      "end": 103.13,
+      "text": "99 % it's an auto So you better",
       "words": [
         {
           "word": "99",
@@ -3030,22 +3021,22 @@
           "start": 102.95,
           "end": 103.13,
           "probability": 0.965236485004425
-        },
-        {
-          "word": "respect",
-          "start": 103.13,
-          "end": 103.55,
-          "probability": 0.9915846586227417
         }
       ],
       "speaker": "Skepta"
     },
     {
       "id": 63,
-      "start": 103.55,
+      "start": 103.13,
       "end": 104.09,
-      "text": "your torso",
+      "text": "respect your torso",
       "words": [
+        {
+          "word": "respect",
+          "start": 103.13,
+          "end": 103.55,
+          "probability": 0.9915846586227417
+        },
         {
           "word": "your",
           "start": 103.55,
@@ -3127,8 +3118,8 @@
     {
       "id": 65,
       "start": 109.03,
-      "end": 111.47,
-      "text": "Danger Tell these babies there's no space in the",
+      "end": 111.19,
+      "text": "Danger Tell these babies there's no space",
       "words": [
         {
           "word": "Danger",
@@ -3171,7 +3162,16 @@
           "start": 110.95,
           "end": 111.19,
           "probability": 0.9909945130348206
-        },
+        }
+      ],
+      "speaker": "Skepta"
+    },
+    {
+      "id": 66,
+      "start": 111.19,
+      "end": 111.73,
+      "text": "in the manger",
+      "words": [
         {
           "word": "in",
           "start": 111.19,
@@ -3183,16 +3183,7 @@
           "start": 111.37,
           "end": 111.47,
           "probability": 0.5694700479507446
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 66,
-      "start": 111.47,
-      "end": 111.73,
-      "text": "manger",
-      "words": [
+        },
         {
           "word": "manger",
           "start": 111.47,
@@ -4135,8 +4126,8 @@
     {
       "id": 85,
       "start": 148.31,
-      "end": 150.95,
-      "text": "5 for 5 and I'm vibing Music artists and",
+      "end": 150.81,
+      "text": "5 for 5 and I'm vibing Music artists",
       "words": [
         {
           "word": "5",
@@ -4185,22 +4176,22 @@
           "start": 150.37,
           "end": 150.81,
           "probability": 0.65003502368927
-        },
-        {
-          "word": "and",
-          "start": 150.81,
-          "end": 150.95,
-          "probability": 0.8340951204299927
         }
       ],
       "speaker": "Shorty"
     },
     {
       "id": 86,
-      "start": 150.95,
+      "start": 150.81,
       "end": 151.57,
-      "text": "I'm rising",
+      "text": "and I'm rising",
       "words": [
+        {
+          "word": "and",
+          "start": 150.81,
+          "end": 150.95,
+          "probability": 0.8340951204299927
+        },
         {
           "word": "I'm",
           "start": 150.95,
@@ -4531,8 +4522,8 @@
     {
       "id": 93,
       "start": 161.83,
-      "end": 163.91,
-      "text": "Alright check this Mash up the rave with no",
+      "end": 163.65,
+      "text": "Alright check this Mash up the rave with",
       "words": [
         {
           "word": "Alright",
@@ -4581,22 +4572,22 @@
           "start": 163.47,
           "end": 163.65,
           "probability": 0.9804254174232483
-        },
-        {
-          "word": "no",
-          "start": 163.65,
-          "end": 163.91,
-          "probability": 0.9785048961639404
         }
       ],
       "speaker": "JME"
     },
     {
       "id": 94,
-      "start": 163.91,
+      "start": 163.65,
       "end": 164.37,
-      "text": "set list",
+      "text": "no set list",
       "words": [
+        {
+          "word": "no",
+          "start": 163.65,
+          "end": 163.91,
+          "probability": 0.9785048961639404
+        },
         {
           "word": "set",
           "start": 163.91,
@@ -5449,8 +5440,8 @@
     {
       "id": 111,
       "start": 190.47,
-      "end": 192.13,
-      "text": "Never came for fame I came to make my",
+      "end": 191.89,
+      "text": "Never came for fame I came to make",
       "words": [
         {
           "word": "Never",
@@ -5499,22 +5490,22 @@
           "start": 191.77,
           "end": 191.89,
           "probability": 0.9924330711364746
-        },
-        {
-          "word": "my",
-          "start": 191.89,
-          "end": 192.13,
-          "probability": 0.9511753916740417
         }
       ],
       "speaker": "Frisco"
     },
     {
       "id": 112,
-      "start": 192.13,
+      "start": 191.89,
       "end": 192.53,
-      "text": "P's blood",
+      "text": "my P's blood",
       "words": [
+        {
+          "word": "my",
+          "start": 191.89,
+          "end": 192.13,
+          "probability": 0.9511753916740417
+        },
         {
           "word": "P's",
           "start": 192.13,
@@ -5812,8 +5803,8 @@
     {
       "id": 118,
       "start": 201.05,
-      "end": 202.45,
-      "text": "what I want how I want when I feel",
+      "end": 202.01,
+      "text": "what I want how I want when",
       "words": [
         {
           "word": "what",
@@ -5856,7 +5847,16 @@
           "start": 201.87,
           "end": 202.01,
           "probability": 0.7518973350524902
-        },
+        }
+      ],
+      "speaker": "Frisco"
+    },
+    {
+      "id": 119,
+      "start": 202.01,
+      "end": 202.77,
+      "text": "I feel like",
+      "words": [
         {
           "word": "I",
           "start": 202.01,
@@ -5868,16 +5868,7 @@
           "start": 202.21,
           "end": 202.45,
           "probability": 0.9925577640533447
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 119,
-      "start": 202.45,
-      "end": 202.77,
-      "text": "like",
-      "words": [
+        },
         {
           "word": "like",
           "start": 202.45,
@@ -6304,8 +6295,8 @@
     {
       "id": 128,
       "start": 216.15,
-      "end": 218.93,
-      "text": "Brand new comeback reinvented And I ain't taking back",
+      "end": 218.67,
+      "text": "Brand new comeback reinvented And I ain't taking",
       "words": [
         {
           "word": "Brand",
@@ -6354,22 +6345,22 @@
           "start": 218.43,
           "end": 218.67,
           "probability": 0.7939057946205139
-        },
-        {
-          "word": "back",
-          "start": 218.67,
-          "end": 218.93,
-          "probability": 0.99122554063797
         }
       ],
       "speaker": "Frisco"
     },
     {
       "id": 129,
-      "start": 218.93,
+      "start": 218.67,
       "end": 219.23,
-      "text": "no talk",
+      "text": "back no talk",
       "words": [
+        {
+          "word": "back",
+          "start": 218.67,
+          "end": 218.93,
+          "probability": 0.99122554063797
+        },
         {
           "word": "no",
           "start": 218.93,
@@ -6388,8 +6379,8 @@
     {
       "id": 130,
       "start": 219.23,
-      "end": 220.79,
-      "text": "Cause I wouldn't have said it if I never",
+      "end": 220.53,
+      "text": "Cause I wouldn't have said it if I",
       "words": [
         {
           "word": "Cause",
@@ -6438,22 +6429,22 @@
           "start": 220.43,
           "end": 220.53,
           "probability": 0.9703086018562317
-        },
-        {
-          "word": "never",
-          "start": 220.53,
-          "end": 220.79,
-          "probability": 0.968353271484375
         }
       ],
       "speaker": "Frisco"
     },
     {
       "id": 131,
-      "start": 220.79,
+      "start": 220.53,
       "end": 221.33,
-      "text": "meant it",
+      "text": "never meant it",
       "words": [
+        {
+          "word": "never",
+          "start": 220.53,
+          "end": 220.79,
+          "probability": 0.968353271484375
+        },
         {
           "word": "meant",
           "start": 220.79,
@@ -6706,8 +6697,8 @@
     {
       "id": 136,
       "start": 227.91,
-      "end": 230.81,
-      "text": "Still going to skeg man more In case he",
+      "end": 230.65,
+      "text": "Still going to skeg man more In case",
       "words": [
         {
           "word": "Still",
@@ -6756,22 +6747,22 @@
           "start": 230.47,
           "end": 230.65,
           "probability": 0.9803598523139954
-        },
-        {
-          "word": "he",
-          "start": 230.65,
-          "end": 230.81,
-          "probability": 0.6177960634231567
         }
       ],
       "speaker": "Frisco"
     },
     {
       "id": 137,
-      "start": 230.81,
+      "start": 230.65,
       "end": 231.83,
-      "text": "fucks up",
+      "text": "he fucks up",
       "words": [
+        {
+          "word": "he",
+          "start": 230.65,
+          "end": 230.81,
+          "probability": 0.6177960634231567
+        },
         {
           "word": "fucks",
           "start": 230.81,
@@ -6790,8 +6781,8 @@
     {
       "id": 138,
       "start": 231.83,
-      "end": 235.81,
-      "text": "Them man know I'm ready for combat Prepare for",
+      "end": 235.65,
+      "text": "Them man know I'm ready for combat Prepare",
       "words": [
         {
           "word": "Them",
@@ -6840,22 +6831,22 @@
           "start": 234.73,
           "end": 235.65,
           "probability": 0.7917049527168274
-        },
-        {
-          "word": "for",
-          "start": 235.65,
-          "end": 235.81,
-          "probability": 0.9951328635215759
         }
       ],
       "speaker": "Frisco"
     },
     {
       "id": 139,
-      "start": 235.81,
+      "start": 235.65,
       "end": 236.37,
-      "text": "the worst",
+      "text": "for the worst",
       "words": [
+        {
+          "word": "for",
+          "start": 235.65,
+          "end": 235.81,
+          "probability": 0.9951328635215759
+        },
         {
           "word": "the",
           "start": 235.81,
@@ -7273,8 +7264,8 @@
     {
       "id": 147,
       "start": 249.99,
-      "end": 252.69,
-      "text": "My eyebrows red oh yeah For Escobar I smoked",
+      "end": 252.49,
+      "text": "My eyebrows red oh yeah For Escobar I",
       "words": [
         {
           "word": "My",
@@ -7323,22 +7314,22 @@
           "start": 252.31,
           "end": 252.49,
           "probability": 0.8747376203536987
-        },
-        {
-          "word": "smoked",
-          "start": 252.49,
-          "end": 252.69,
-          "probability": 0.6370925903320312
         }
       ],
       "speaker": "Jammer"
     },
     {
       "id": 148,
-      "start": 252.69,
+      "start": 252.49,
       "end": 253.27,
-      "text": "the herbal",
+      "text": "smoked the herbal",
       "words": [
+        {
+          "word": "smoked",
+          "start": 252.49,
+          "end": 252.69,
+          "probability": 0.6370925903320312
+        },
         {
           "word": "the",
           "start": 252.69,
@@ -7420,8 +7411,8 @@
     {
       "id": 150,
       "start": 255.39,
-      "end": 256.69,
-      "text": ".P for my fam that I lost in the",
+      "end": 256.37,
+      "text": ".P for my fam that I lost",
       "words": [
         {
           "word": ".P",
@@ -7464,7 +7455,16 @@
           "start": 256.25,
           "end": 256.37,
           "probability": 0.9159753918647766
-        },
+        }
+      ],
+      "speaker": "Jammer"
+    },
+    {
+      "id": 151,
+      "start": 256.37,
+      "end": 257.01,
+      "text": "in the past",
+      "words": [
         {
           "word": "in",
           "start": 256.37,
@@ -7476,16 +7476,7 @@
           "start": 256.57,
           "end": 256.69,
           "probability": 0.9953000545501709
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 151,
-      "start": 256.69,
-      "end": 257.01,
-      "text": "past",
-      "words": [
+        },
         {
           "word": "past",
           "start": 256.69,
@@ -7498,8 +7489,8 @@
     {
       "id": 152,
       "start": 257.01,
-      "end": 259.25,
-      "text": "Trust I said well When I come through it's",
+      "end": 258.73,
+      "text": "Trust I said well When I come",
       "words": [
         {
           "word": "Trust",
@@ -7542,7 +7533,16 @@
           "start": 258.51,
           "end": 258.73,
           "probability": 0.9861918687820435
-        },
+        }
+      ],
+      "speaker": "Jammer"
+    },
+    {
+      "id": 153,
+      "start": 258.73,
+      "end": 259.49,
+      "text": "through it's warning",
+      "words": [
         {
           "word": "through",
           "start": 258.73,
@@ -7554,16 +7554,7 @@
           "start": 258.93,
           "end": 259.25,
           "probability": 0.8510830700397491
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 153,
-      "start": 259.25,
-      "end": 259.49,
-      "text": "warning",
-      "words": [
+        },
         {
           "word": "warning",
           "start": 259.25,
@@ -7915,8 +7906,8 @@
     {
       "id": 161,
       "start": 272.69,
-      "end": 274.81,
-      "text": "Salt and pepper S man the bass watch no",
+      "end": 274.25,
+      "text": "Salt and pepper S man the bass",
       "words": [
         {
           "word": "Salt",
@@ -7959,7 +7950,16 @@
           "start": 274.03,
           "end": 274.25,
           "probability": 0.47908735275268555
-        },
+        }
+      ],
+      "speaker": "Jammer"
+    },
+    {
+      "id": 162,
+      "start": 274.25,
+      "end": 275.11,
+      "text": "watch no face",
+      "words": [
         {
           "word": "watch",
           "start": 274.25,
@@ -7971,16 +7971,7 @@
           "start": 274.57,
           "end": 274.81,
           "probability": 0.9115926027297974
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 162,
-      "start": 274.81,
-      "end": 275.11,
-      "text": "face",
-      "words": [
+        },
         {
           "word": "face",
           "start": 274.81,
@@ -7993,8 +7984,8 @@
     {
       "id": 163,
       "start": 275.11,
-      "end": 276.91,
-      "text": "We put the work in Black and black across",
+      "end": 276.65,
+      "text": "We put the work in Black and black",
       "words": [
         {
           "word": "We",
@@ -8043,22 +8034,22 @@
           "start": 276.53,
           "end": 276.65,
           "probability": 0.10698377341032028
-        },
-        {
-          "word": "across",
-          "start": 276.65,
-          "end": 276.91,
-          "probability": 0.742216169834137
         }
       ],
       "speaker": "Jammer"
     },
     {
       "id": 164,
-      "start": 276.91,
+      "start": 276.65,
       "end": 277.17,
-      "text": "the deck",
+      "text": "across the deck",
       "words": [
+        {
+          "word": "across",
+          "start": 276.65,
+          "end": 276.91,
+          "probability": 0.742216169834137
+        },
         {
           "word": "the",
           "start": 276.91,
@@ -9052,8 +9043,8 @@
     {
       "id": 184,
       "start": 310.85,
-      "end": 312.85,
-      "text": "get to save my piece Can't believe the singles",
+      "end": 312.61,
+      "text": "get to save my piece Can't believe the",
       "words": [
         {
           "word": "get",
@@ -9102,22 +9093,22 @@
           "start": 312.39,
           "end": 312.61,
           "probability": 0.9934158325195312
-        },
-        {
-          "word": "singles",
-          "start": 312.61,
-          "end": 312.85,
-          "probability": 0.9783932566642761
         }
       ],
       "speaker": "Skepta"
     },
     {
       "id": 185,
-      "start": 312.85,
+      "start": 312.61,
       "end": 313.49,
-      "text": "I released",
+      "text": "singles I released",
       "words": [
+        {
+          "word": "singles",
+          "start": 312.61,
+          "end": 312.85,
+          "probability": 0.9783932566642761
+        },
         {
           "word": "I",
           "start": 312.85,
@@ -9311,26 +9302,17 @@
       "speaker": "Skepta"
     },
     {
-      "id": 189,
+      "id": 190,
       "start": 318.41,
-      "end": 318.79,
-      "text": "for",
+      "end": 320.53,
+      "text": "for Ayy Logan",
       "words": [
         {
           "word": "for",
           "start": 318.41,
           "end": 318.79,
           "probability": 0.5183525085449219
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 190,
-      "start": 319.53,
-      "end": 320.53,
-      "text": "Ayy Logan",
-      "words": [
+        },
         {
           "word": "Ayy",
           "start": 319.53,
@@ -9506,26 +9488,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 194,
+      "id": 195,
       "start": 329.13,
-      "end": 329.87,
-      "text": "Logan",
+      "end": 330.89,
+      "text": "Logan And Jim!",
       "words": [
         {
           "word": "Logan",
           "start": 329.13,
           "end": 329.87,
           "probability": 0.48471254110336304
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 195,
-      "start": 329.87,
-      "end": 330.89,
-      "text": "And Jim!",
-      "words": [
+        },
         {
           "word": "And",
           "start": 329.87,
@@ -9628,8 +9601,8 @@
     {
       "id": 198,
       "start": 333.81,
-      "end": 334.73,
-      "text": "Oh my god",
+      "end": 335.79,
+      "text": "Oh my god Jacum! Jacum!",
       "words": [
         {
           "word": "Oh",
@@ -9648,31 +9621,13 @@
           "start": 334.49,
           "end": 334.73,
           "probability": 0.4905370771884918
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 199,
-      "start": 334.73,
-      "end": 335.15,
-      "text": "Jacum!",
-      "words": [
+        },
         {
           "word": "Jacum!",
           "start": 334.73,
           "end": 335.15,
           "probability": 0.1691773720085621
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 200,
-      "start": 335.27,
-      "end": 335.79,
-      "text": "Jacum!",
-      "words": [
+        },
         {
           "word": "Jacum!",
           "start": 335.27,
@@ -10025,26 +9980,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 215,
+      "id": 216,
       "start": 358.41,
-      "end": 358.91,
-      "text": "easy,",
+      "end": 359.83,
+      "text": "easy, you done know",
       "words": [
         {
           "word": "easy,",
           "start": 358.41,
           "end": 358.91,
           "probability": 0.962226927280426
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 216,
-      "start": 359.17,
-      "end": 359.83,
-      "text": "you done know",
-      "words": [
+        },
         {
           "word": "you",
           "start": 359.17,
@@ -10069,8 +10015,8 @@
     {
       "id": 217,
       "start": 359.83,
-      "end": 362.27,
-      "text": "Too much style for one flow So try interrupt",
+      "end": 361.95,
+      "text": "Too much style for one flow So try",
       "words": [
         {
           "word": "Too",
@@ -10119,22 +10065,22 @@
           "start": 361.79,
           "end": 361.95,
           "probability": 0.836205005645752
-        },
-        {
-          "word": "interrupt",
-          "start": 361.95,
-          "end": 362.27,
-          "probability": 0.45384615659713745
         }
       ],
       "speaker": "Frisco"
     },
     {
       "id": 218,
-      "start": 362.27,
+      "start": 361.95,
       "end": 362.95,
-      "text": "my income",
+      "text": "interrupt my income",
       "words": [
+        {
+          "word": "interrupt",
+          "start": 361.95,
+          "end": 362.27,
+          "probability": 0.45384615659713745
+        },
         {
           "word": "my",
           "start": 362.27,
@@ -10214,10 +10160,10 @@
       "speaker": "Frisco"
     },
     {
-      "id": 220,
+      "id": 221,
       "start": 365.53,
-      "end": 366.73,
-      "text": "Jamek Power",
+      "end": 368.45,
+      "text": "Jamek Power Merkle Man",
       "words": [
         {
           "word": "Jamek",
@@ -10230,16 +10176,7 @@
           "start": 366.13,
           "end": 366.73,
           "probability": 0.33959323167800903
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 221,
-      "start": 366.73,
-      "end": 368.45,
-      "text": "Merkle Man",
-      "words": [
+        },
         {
           "word": "Merkle",
           "start": 366.73,
@@ -10291,8 +10228,8 @@
     {
       "id": 223,
       "start": 370.11,
-      "end": 371.39,
-      "text": "I don't circle Man",
+      "end": 375.13,
+      "text": "I don't circle Man Green Bandana Purple Gang",
       "words": [
         {
           "word": "I",
@@ -10317,16 +10254,7 @@
           "start": 371.07,
           "end": 371.39,
           "probability": 0.4892610013484955
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 224,
-      "start": 372.07,
-      "end": 373.07,
-      "text": "Green Bandana",
-      "words": [
+        },
         {
           "word": "Green",
           "start": 372.07,
@@ -10338,16 +10266,7 @@
           "start": 372.49,
           "end": 373.07,
           "probability": 0.8264071345329285
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 225,
-      "start": 373.93,
-      "end": 375.13,
-      "text": "Purple Gang",
-      "words": [
+        },
         {
           "word": "Purple",
           "start": 373.93,
@@ -10364,10 +10283,10 @@
       "speaker": "Jammer"
     },
     {
-      "id": 226,
+      "id": 227,
       "start": 375.13,
-      "end": 376.39,
-      "text": "Or Robert",
+      "end": 378.31,
+      "text": "Or Robert Purple Man",
       "words": [
         {
           "word": "Or",
@@ -10380,16 +10299,7 @@
           "start": 375.69,
           "end": 376.39,
           "probability": 0.4852752089500427
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 227,
-      "start": 377.12,
-      "end": 378.31,
-      "text": "Purple Man",
-      "words": [
+        },
         {
           "word": "Purple",
           "start": 377.12,
@@ -10408,8 +10318,8 @@
     {
       "id": 228,
       "start": 378.31,
-      "end": 380.03,
-      "text": "I think I'm legendary",
+      "end": 383.61,
+      "text": "I think I'm legendary Scratch Perry iPhone 4",
       "words": [
         {
           "word": "I",
@@ -10434,16 +10344,7 @@
           "start": 379.19,
           "end": 380.03,
           "probability": 0.7486281394958496
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 229,
-      "start": 380.03,
-      "end": 381.83,
-      "text": "Scratch Perry",
-      "words": [
+        },
         {
           "word": "Scratch",
           "start": 380.03,
@@ -10455,16 +10356,7 @@
           "start": 381.17,
           "end": 381.83,
           "probability": 0.7922332286834717
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 230,
-      "start": 381.83,
-      "end": 383.61,
-      "text": "iPhone 4",
-      "words": [
+        },
         {
           "word": "iPhone",
           "start": 381.83,
@@ -10543,8 +10435,8 @@
     {
       "id": 233,
       "start": 386.97,
-      "end": 388.44,
-      "text": "A Papa Jerry",
+      "end": 393.7,
+      "text": "A Papa Jerry Good French Lenny Henry Nando's",
       "words": [
         {
           "word": "A",
@@ -10563,16 +10455,7 @@
           "start": 387.87,
           "end": 388.44,
           "probability": 0.945883572101593
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 234,
-      "start": 388.85,
-      "end": 390.0,
-      "text": "Good French",
-      "words": [
+        },
         {
           "word": "Good",
           "start": 388.85,
@@ -10584,16 +10467,7 @@
           "start": 389.43,
           "end": 390.0,
           "probability": 0.9091206192970276
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 235,
-      "start": 390.47,
-      "end": 391.84,
-      "text": "Lenny Henry",
-      "words": [
+        },
         {
           "word": "Lenny",
           "start": 390.47,
@@ -10605,16 +10479,7 @@
           "start": 391.27,
           "end": 391.84,
           "probability": 0.9662008285522461
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 236,
-      "start": 393.13,
-      "end": 393.7,
-      "text": "Nando's",
-      "words": [
+        },
         {
           "word": "Nando's",
           "start": 393.13,
@@ -10625,10 +10490,10 @@
       "speaker": "Jammer"
     },
     {
-      "id": 237,
+      "id": 238,
       "start": 394.27,
-      "end": 395.39,
-      "text": "Perry Perry",
+      "end": 398.65,
+      "text": "Perry Perry A kiss a chick Katy Perry",
       "words": [
         {
           "word": "Perry",
@@ -10641,16 +10506,7 @@
           "start": 394.61,
           "end": 395.39,
           "probability": 0.9800281524658203
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 238,
-      "start": 395.39,
-      "end": 397.35,
-      "text": "A kiss a chick",
-      "words": [
+        },
         {
           "word": "A",
           "start": 395.39,
@@ -10674,16 +10530,7 @@
           "start": 396.43,
           "end": 397.35,
           "probability": 0.916210412979126
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 239,
-      "start": 397.35,
-      "end": 398.65,
-      "text": "Katy Perry",
-      "words": [
+        },
         {
           "word": "Katy",
           "start": 397.35,
@@ -10795,8 +10642,8 @@
     {
       "id": 243,
       "start": 404.31,
-      "end": 405.13,
-      "text": "R .F .E.",
+      "end": 405.65,
+      "text": "R .F .E. Shorty",
       "words": [
         {
           "word": "R",
@@ -10815,16 +10662,7 @@
           "start": 404.99,
           "end": 405.13,
           "probability": 0.5514729768037796
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 244,
-      "start": 405.25,
-      "end": 405.65,
-      "text": "Shorty",
-      "words": [
+        },
         {
           "word": "Shorty",
           "start": 405.25,
@@ -10837,8 +10675,8 @@
     {
       "id": 245,
       "start": 405.65,
-      "end": 406.71,
-      "text": "I'm the smallest one",
+      "end": 408.39,
+      "text": "I'm the smallest one 5 '5 Everything's live",
       "words": [
         {
           "word": "I'm",
@@ -10863,16 +10701,7 @@
           "start": 406.29,
           "end": 406.71,
           "probability": 0.9711722135543823
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 246,
-      "start": 406.71,
-      "end": 407.41,
-      "text": "5 '5",
-      "words": [
+        },
         {
           "word": "5",
           "start": 406.71,
@@ -10884,16 +10713,7 @@
           "start": 407.07,
           "end": 407.41,
           "probability": 0.4458566904067993
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 247,
-      "start": 407.85,
-      "end": 408.39,
-      "text": "Everything's live",
-      "words": [
+        },
         {
           "word": "Everything's",
           "start": 407.85,
@@ -11279,26 +11099,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 255,
+      "id": 256,
       "start": 418.71,
-      "end": 418.91,
-      "text": "on",
+      "end": 420.45,
+      "text": "on When I say BBK Sing along",
       "words": [
         {
           "word": "on",
           "start": 418.71,
           "end": 418.91,
           "probability": 0.998145341873169
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 256,
-      "start": 418.91,
-      "end": 419.99,
-      "text": "When I say BBK",
-      "words": [
+        },
         {
           "word": "When",
           "start": 418.91,
@@ -11322,16 +11133,7 @@
           "start": 419.43,
           "end": 419.99,
           "probability": 0.8760689198970795
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 257,
-      "start": 419.99,
-      "end": 420.45,
-      "text": "Sing along",
-      "words": [
+        },
         {
           "word": "Sing",
           "start": 419.99,
@@ -11350,8 +11152,8 @@
     {
       "id": 258,
       "start": 420.45,
-      "end": 421.67,
-      "text": "We need some more girls in here",
+      "end": 422.31,
+      "text": "We need some more girls in here Sing along",
       "words": [
         {
           "word": "We",
@@ -11394,16 +11196,7 @@
           "start": 421.61,
           "end": 421.67,
           "probability": 0.9770673513412476
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 259,
-      "start": 421.67,
-      "end": 422.31,
-      "text": "Sing along",
-      "words": [
+        },
         {
           "word": "Sing",
           "start": 421.67,
@@ -11530,8 +11323,8 @@
     {
       "id": 262,
       "start": 425.69,
-      "end": 426.55,
-      "text": "Boy better know",
+      "end": 427.55,
+      "text": "Boy better know CEO",
       "words": [
         {
           "word": "Boy",
@@ -11550,16 +11343,7 @@
           "start": 426.17,
           "end": 426.55,
           "probability": 0.9851104021072388
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 263,
-      "start": 427.15,
-      "end": 427.55,
-      "text": "CEO",
-      "words": [
+        },
         {
           "word": "CEO",
           "start": 427.15,
@@ -11572,8 +11356,8 @@
     {
       "id": 264,
       "start": 427.55,
-      "end": 428.31,
-      "text": "Sharp your mat",
+      "end": 428.93,
+      "text": "Sharp your mat Sing along",
       "words": [
         {
           "word": "Sharp",
@@ -11592,16 +11376,7 @@
           "start": 428.13,
           "end": 428.31,
           "probability": 0.22630378603935242
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 265,
-      "start": 428.31,
-      "end": 428.93,
-      "text": "Sing along",
-      "words": [
+        },
         {
           "word": "Sing",
           "start": 428.31,
@@ -12122,41 +11897,23 @@
       "speaker": "Frisco"
     },
     {
-      "id": 276,
+      "id": 278,
       "start": 447.39,
-      "end": 447.83,
-      "text": "Yeah",
+      "end": 451.17,
+      "text": "Yeah Logan Boy better know in session full crew",
       "words": [
         {
           "word": "Yeah",
           "start": 447.39,
           "end": 447.83,
           "probability": 0.3357374370098114
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 277,
-      "start": 448.63,
-      "end": 449.07,
-      "text": "Logan",
-      "words": [
+        },
         {
           "word": "Logan",
           "start": 448.63,
           "end": 449.07,
           "probability": 0.5385593771934509
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 278,
-      "start": 449.07,
-      "end": 451.17,
-      "text": "Boy better know in session full crew",
-      "words": [
+        },
         {
           "word": "Boy",
           "start": 449.07,
@@ -12205,8 +11962,8 @@
     {
       "id": 279,
       "start": 451.17,
-      "end": 453.35,
-      "text": "Big shout to Solo45",
+      "end": 454.17,
+      "text": "Big shout to Solo45 Wiley",
       "words": [
         {
           "word": "Big",
@@ -12231,16 +11988,7 @@
           "start": 452.03,
           "end": 453.35,
           "probability": 0.508558377623558
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 280,
-      "start": 453.35,
-      "end": 454.17,
-      "text": "Wiley",
-      "words": [
+        },
         {
           "word": "Wiley",
           "start": 453.35,
@@ -12253,8 +12001,8 @@
     {
       "id": 281,
       "start": 454.17,
-      "end": 456.43,
-      "text": "Maximum can't forget Sam that's BBK",
+      "end": 458.83,
+      "text": "Maximum can't forget Sam that's BBK Listen Yeah Yeah",
       "words": [
         {
           "word": "Maximum",
@@ -12291,46 +12039,19 @@
           "start": 455.95,
           "end": 456.43,
           "probability": 0.9105907082557678
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 282,
-      "start": 457.09,
-      "end": 457.53,
-      "text": "Listen",
-      "words": [
+        },
         {
           "word": "Listen",
           "start": 457.09,
           "end": 457.53,
           "probability": 0.5300664305686951
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 283,
-      "start": 457.53,
-      "end": 458.23,
-      "text": "Yeah",
-      "words": [
+        },
         {
           "word": "Yeah",
           "start": 457.53,
           "end": 458.23,
           "probability": 0.49704697728157043
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 284,
-      "start": 458.23,
-      "end": 458.83,
-      "text": "Yeah",
-      "words": [
+        },
         {
           "word": "Yeah",
           "start": 458.23,
@@ -12524,10 +12245,10 @@
       "speaker": "Skepta"
     },
     {
-      "id": 288,
+      "id": 289,
       "start": 463.91,
-      "end": 464.51,
-      "text": "my CD",
+      "end": 465.83,
+      "text": "my CD Look in the mirror and mine",
       "words": [
         {
           "word": "my",
@@ -12540,16 +12261,7 @@
           "start": 464.17,
           "end": 464.51,
           "probability": 0.8979441523551941
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 289,
-      "start": 464.51,
-      "end": 465.83,
-      "text": "Look in the mirror and mine",
-      "words": [
+        },
         {
           "word": "Look",
           "start": 464.51,
@@ -13220,26 +12932,17 @@
       "speaker": "Skepta"
     },
     {
-      "id": 302,
+      "id": 303,
       "start": 486.05,
-      "end": 486.61,
-      "text": "around",
+      "end": 488.07,
+      "text": "around With a flow that broke down",
       "words": [
         {
           "word": "around",
           "start": 486.05,
           "end": 486.61,
           "probability": 0.987199604511261
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 303,
-      "start": 486.61,
-      "end": 488.07,
-      "text": "With a flow that broke down",
-      "words": [
+        },
         {
           "word": "With",
           "start": 486.61,
@@ -13564,8 +13267,8 @@
     {
       "id": 310,
       "start": 498.43,
-      "end": 500.55,
-      "text": "Nocturnal creature like chipmunk in a league of my",
+      "end": 500.23,
+      "text": "Nocturnal creature like chipmunk in a league",
       "words": [
         {
           "word": "Nocturnal",
@@ -13608,7 +13311,16 @@
           "start": 500.11,
           "end": 500.23,
           "probability": 0.9882782101631165
-        },
+        }
+      ],
+      "speaker": "Skepta"
+    },
+    {
+      "id": 311,
+      "start": 500.23,
+      "end": 500.99,
+      "text": "of my own",
+      "words": [
         {
           "word": "of",
           "start": 500.23,
@@ -13620,16 +13332,7 @@
           "start": 500.37,
           "end": 500.55,
           "probability": 0.984778106212616
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 311,
-      "start": 500.55,
-      "end": 500.99,
-      "text": "own",
-      "words": [
+        },
         {
           "word": "own",
           "start": 500.55,
@@ -13966,8 +13669,8 @@
     {
       "id": 320,
       "start": 510.99,
-      "end": 512.59,
-      "text": "Skepto I'm in my own zone",
+      "end": 513.83,
+      "text": "Skepto I'm in my own zone Yeah Capital",
       "words": [
         {
           "word": "Skepto",
@@ -14004,52 +13707,34 @@
           "start": 512.35,
           "end": 512.59,
           "probability": 0.9938474297523499
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 321,
-      "start": 512.59,
-      "end": 513.17,
-      "text": "Yeah",
-      "words": [
+        },
         {
           "word": "Yeah",
           "start": 512.59,
           "end": 513.17,
           "probability": 0.3308185040950775
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 322,
-      "start": 513.17,
-      "end": 514.17,
-      "text": "Capital J,",
-      "words": [
+        },
         {
           "word": "Capital",
           "start": 513.17,
           "end": 513.83,
           "probability": 0.022371478378772736
-        },
-        {
-          "word": "J,",
-          "start": 513.83,
-          "end": 514.17,
-          "probability": 0.9392639994621277
         }
       ],
       "speaker": "Skepta"
     },
     {
       "id": 323,
-      "start": 514.23,
+      "start": 513.83,
       "end": 514.55,
-      "text": "little M,",
+      "text": "J, little M,",
       "words": [
+        {
+          "word": "J,",
+          "start": 513.83,
+          "end": 514.17,
+          "probability": 0.9392639994621277
+        },
         {
           "word": "little",
           "start": 514.23,
@@ -14395,8 +14080,8 @@
     {
       "id": 331,
       "start": 523.57,
-      "end": 525.27,
-      "text": "Big 5 series not a little 3",
+      "end": 526.07,
+      "text": "Big 5 series not a little 3 Swag, swag",
       "words": [
         {
           "word": "Big",
@@ -14439,31 +14124,13 @@
           "start": 524.85,
           "end": 525.27,
           "probability": 0.5311781764030457
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 332,
-      "start": 525.27,
-      "end": 525.73,
-      "text": "Swag,",
-      "words": [
+        },
         {
           "word": "Swag,",
           "start": 525.27,
           "end": 525.73,
           "probability": 0.6160338670015335
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 333,
-      "start": 525.73,
-      "end": 526.07,
-      "text": "swag",
-      "words": [
+        },
         {
           "word": "swag",
           "start": 525.73,
@@ -14476,8 +14143,8 @@
     {
       "id": 334,
       "start": 526.07,
-      "end": 526.93,
-      "text": "Like a little B",
+      "end": 527.77,
+      "text": "Like a little B Capital J, little",
       "words": [
         {
           "word": "Like",
@@ -14502,16 +14169,7 @@
           "start": 526.65,
           "end": 526.93,
           "probability": 0.8833440542221069
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 335,
-      "start": 526.93,
-      "end": 527.59,
-      "text": "Capital J,",
-      "words": [
+        },
         {
           "word": "Capital",
           "start": 526.93,
@@ -14523,37 +14181,28 @@
           "start": 527.31,
           "end": 527.59,
           "probability": 0.964665412902832
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 336,
-      "start": 527.61,
-      "end": 527.99,
-      "text": "little M,",
-      "words": [
+        },
         {
           "word": "little",
           "start": 527.61,
           "end": 527.77,
           "probability": 0.8548870086669922
-        },
-        {
-          "word": "M,",
-          "start": 527.77,
-          "end": 527.99,
-          "probability": 0.9635591506958008
         }
       ],
       "speaker": "JME"
     },
     {
       "id": 337,
-      "start": 527.99,
+      "start": 527.77,
       "end": 528.59,
-      "text": "little E",
+      "text": "M, little E",
       "words": [
+        {
+          "word": "M,",
+          "start": 527.77,
+          "end": 527.99,
+          "probability": 0.9635591506958008
+        },
         {
           "word": "little",
           "start": 527.99,
@@ -14917,8 +14566,8 @@
     {
       "id": 345,
       "start": 538.75,
-      "end": 539.71,
-      "text": "Big 5 series",
+      "end": 541.55,
+      "text": "Big 5 series Never had",
       "words": [
         {
           "word": "Big",
@@ -14937,16 +14586,7 @@
           "start": 539.31,
           "end": 539.71,
           "probability": 0.1473952680826187
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 346,
-      "start": 540.67,
-      "end": 541.55,
-      "text": "Never had",
-      "words": [
+        },
         {
           "word": "Never",
           "start": 540.67,
@@ -14965,8 +14605,8 @@
     {
       "id": 347,
       "start": 542.19,
-      "end": 543.11,
-      "text": "I never had",
+      "end": 546.03,
+      "text": "I never had Swag",
       "words": [
         {
           "word": "I",
@@ -14985,16 +14625,7 @@
           "start": 542.89,
           "end": 543.11,
           "probability": 0.9923601746559143
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 348,
-      "start": 545.59,
-      "end": 546.03,
-      "text": "Swag",
-      "words": [
+        },
         {
           "word": "Swag",
           "start": 545.59,
@@ -15032,26 +14663,17 @@
       "speaker": "unknown"
     },
     {
-      "id": 350,
+      "id": 351,
       "start": 548.07,
-      "end": 548.51,
-      "text": "Listen",
+      "end": 550.09,
+      "text": "Listen Gold chain remix",
       "words": [
         {
           "word": "Listen",
           "start": 548.07,
           "end": 548.51,
           "probability": 0.9042399525642395
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 351,
-      "start": 548.51,
-      "end": 550.09,
-      "text": "Gold chain remix",
-      "words": [
+        },
         {
           "word": "Gold",
           "start": 548.51,
@@ -15298,8 +14920,8 @@
     {
       "id": 358,
       "start": 559.21,
-      "end": 560.89,
-      "text": "I'm a star sent for the sofa",
+      "end": 561.75,
+      "text": "I'm a star sent for the sofa I'm a",
       "words": [
         {
           "word": "I'm",
@@ -15342,16 +14964,7 @@
           "start": 560.51,
           "end": 560.89,
           "probability": 0.29462164640426636
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 359,
-      "start": 560.89,
-      "end": 561.75,
-      "text": "I'm a",
-      "words": [
+        },
         {
           "word": "I'm",
           "start": 560.89,
@@ -15368,10 +14981,10 @@
       "speaker": "Jammer"
     },
     {
-      "id": 360,
+      "id": 361,
       "start": 561.75,
-      "end": 562.37,
-      "text": "Ay Logan",
+      "end": 563.55,
+      "text": "Ay Logan Ay Logan",
       "words": [
         {
           "word": "Ay",
@@ -15384,16 +14997,7 @@
           "start": 561.99,
           "end": 562.37,
           "probability": 0.7464371919631958
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 361,
-      "start": 562.37,
-      "end": 563.55,
-      "text": "Ay Logan",
-      "words": [
+        },
         {
           "word": "Ay",
           "start": 562.37,
@@ -15722,26 +15326,17 @@
       "speaker": "Jammer"
     },
     {
-      "id": 370,
+      "id": 371,
       "start": 575.19,
-      "end": 575.57,
-      "text": "B",
+      "end": 576.49,
+      "text": "B On the drop ass,",
       "words": [
         {
           "word": "B",
           "start": 575.19,
           "end": 575.57,
           "probability": 0.9851085543632507
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 371,
-      "start": 575.57,
-      "end": 576.49,
-      "text": "On the drop ass,",
-      "words": [
+        },
         {
           "word": "On",
           "start": 575.57,
@@ -16178,26 +15773,17 @@
       "speaker": "Jammer"
     },
     {
-      "id": 382,
+      "id": 383,
       "start": 588.71,
-      "end": 589.13,
-      "text": "B",
+      "end": 589.99,
+      "text": "B On the drop ass,",
       "words": [
         {
           "word": "B",
           "start": 588.71,
           "end": 589.13,
           "probability": 0.9526758193969727
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 383,
-      "start": 589.13,
-      "end": 589.99,
-      "text": "On the drop ass,",
-      "words": [
+        },
         {
           "word": "On",
           "start": 589.13,
@@ -16304,26 +15890,17 @@
       "speaker": "Jammer"
     },
     {
-      "id": 386,
+      "id": 387,
       "start": 592.23,
-      "end": 592.67,
-      "text": "What?",
+      "end": 595.09,
+      "text": "What? In the A &E Alright then",
       "words": [
         {
           "word": "What?",
           "start": 592.23,
           "end": 592.67,
           "probability": 0.1953422576189041
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 387,
-      "start": 593.13,
-      "end": 594.41,
-      "text": "In the A &E",
-      "words": [
+        },
         {
           "word": "In",
           "start": 593.13,
@@ -16347,16 +15924,7 @@
           "start": 593.67,
           "end": 594.41,
           "probability": 0.972348541021347
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 388,
-      "start": 594.41,
-      "end": 595.09,
-      "text": "Alright then",
-      "words": [
+        },
         {
           "word": "Alright",
           "start": 594.41,
@@ -16436,10 +16004,10 @@
       "speaker": "JME"
     },
     {
-      "id": 390,
+      "id": 391,
       "start": 596.67,
-      "end": 597.35,
-      "text": "Big face,",
+      "end": 598.37,
+      "text": "Big face, gold ticket, baiting",
       "words": [
         {
           "word": "Big",
@@ -16452,16 +16020,7 @@
           "start": 597.07,
           "end": 597.35,
           "probability": 0.8361325860023499
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 391,
-      "start": 597.35,
-      "end": 597.83,
-      "text": "gold ticket,",
-      "words": [
+        },
         {
           "word": "gold",
           "start": 597.35,
@@ -16473,16 +16032,7 @@
           "start": 597.49,
           "end": 597.83,
           "probability": 0.9520241022109985
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 392,
-      "start": 598.09,
-      "end": 598.37,
-      "text": "baiting",
-      "words": [
+        },
         {
           "word": "baiting",
           "start": 598.09,
@@ -16597,8 +16147,8 @@
     {
       "id": 395,
       "start": 601.63,
-      "end": 602.83,
-      "text": "Man will headlock the ticket,",
+      "end": 603.45,
+      "text": "Man will headlock the ticket, inspector",
       "words": [
         {
           "word": "Man",
@@ -16629,16 +16179,7 @@
           "start": 602.65,
           "end": 602.83,
           "probability": 0.9823251962661743
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 396,
-      "start": 602.83,
-      "end": 603.45,
-      "text": "inspector",
-      "words": [
+        },
         {
           "word": "inspector",
           "start": 602.83,
@@ -16702,8 +16243,8 @@
     {
       "id": 398,
       "start": 604.97,
-      "end": 606.79,
-      "text": "Better make it big like Chipie and Skepta",
+      "end": 607.47,
+      "text": "Better make it big like Chipie and Skepta Bruv,",
       "words": [
         {
           "word": "Better",
@@ -16752,16 +16293,7 @@
           "start": 606.43,
           "end": 606.79,
           "probability": 0.5538849383592606
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 399,
-      "start": 606.79,
-      "end": 607.47,
-      "text": "Bruv,",
-      "words": [
+        },
         {
           "word": "Bruv,",
           "start": 606.79,
@@ -16774,8 +16306,8 @@
     {
       "id": 400,
       "start": 607.55,
-      "end": 608.27,
-      "text": "I'm sick on the mic,",
+      "end": 608.65,
+      "text": "I'm sick on the mic, don't hate",
       "words": [
         {
           "word": "I'm",
@@ -16806,16 +16338,7 @@
           "start": 608.13,
           "end": 608.27,
           "probability": 0.9787946939468384
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 401,
-      "start": 608.29,
-      "end": 608.65,
-      "text": "don't hate",
-      "words": [
+        },
         {
           "word": "don't",
           "start": 608.29,
@@ -16873,8 +16396,8 @@
     {
       "id": 403,
       "start": 609.57,
-      "end": 610.41,
-      "text": "too sick on the beat",
+      "end": 610.65,
+      "text": "too sick on the beat Sick,",
       "words": [
         {
           "word": "too",
@@ -16905,16 +16428,7 @@
           "start": 610.23,
           "end": 610.41,
           "probability": 0.8732783794403076
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 404,
-      "start": 610.41,
-      "end": 610.65,
-      "text": "Sick,",
-      "words": [
+        },
         {
           "word": "Sick,",
           "start": 610.41,
@@ -17032,8 +16546,8 @@
     {
       "id": 408,
       "start": 613.95,
-      "end": 615.05,
-      "text": "I come so sick on the mic,",
+      "end": 615.59,
+      "text": "I come so sick on the mic, don't hate",
       "words": [
         {
           "word": "I",
@@ -17076,16 +16590,7 @@
           "start": 614.89,
           "end": 615.05,
           "probability": 0.9873418211936951
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 409,
-      "start": 615.05,
-      "end": 615.59,
-      "text": "don't hate",
-      "words": [
+        },
         {
           "word": "don't",
           "start": 615.05,
@@ -17137,8 +16642,8 @@
     {
       "id": 411,
       "start": 616.41,
-      "end": 617.17,
-      "text": "too sick on the beat",
+      "end": 618.03,
+      "text": "too sick on the beat So sick,",
       "words": [
         {
           "word": "too",
@@ -17169,16 +16674,7 @@
           "start": 617.01,
           "end": 617.17,
           "probability": 0.9945520758628845
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 412,
-      "start": 617.17,
-      "end": 618.03,
-      "text": "So sick,",
-      "words": [
+        },
         {
           "word": "So",
           "start": 617.17,
@@ -17800,8 +17296,8 @@
     {
       "id": 428,
       "start": 636.91,
-      "end": 637.35,
-      "text": "no man chat,",
+      "end": 637.87,
+      "text": "no man chat, no boo",
       "words": [
         {
           "word": "no",
@@ -17820,16 +17316,7 @@
           "start": 637.19,
           "end": 637.35,
           "probability": 0.33679214119911194
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 429,
-      "start": 637.49,
-      "end": 637.87,
-      "text": "no boo",
-      "words": [
+        },
         {
           "word": "no",
           "start": 637.49,
@@ -17881,8 +17368,8 @@
     {
       "id": 431,
       "start": 639.25,
-      "end": 639.93,
-      "text": "there's no party boy",
+      "end": 640.73,
+      "text": "there's no party boy Better know, don't try,",
       "words": [
         {
           "word": "there's",
@@ -17907,16 +17394,7 @@
           "start": 639.73,
           "end": 639.93,
           "probability": 0.42725279927253723
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 432,
-      "start": 639.93,
-      "end": 640.35,
-      "text": "Better know,",
-      "words": [
+        },
         {
           "word": "Better",
           "start": 639.93,
@@ -17928,16 +17406,7 @@
           "start": 640.13,
           "end": 640.35,
           "probability": 0.6045835614204407
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 433,
-      "start": 640.37,
-      "end": 640.73,
-      "text": "don't try,",
-      "words": [
+        },
         {
           "word": "don't",
           "start": 640.37,
@@ -18022,8 +17491,8 @@
     {
       "id": 436,
       "start": 643.55,
-      "end": 644.13,
-      "text": "no man chat,",
+      "end": 644.69,
+      "text": "no man chat, no boo",
       "words": [
         {
           "word": "no",
@@ -18042,16 +17511,7 @@
           "start": 643.93,
           "end": 644.13,
           "probability": 0.9824351668357849
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 437,
-      "start": 644.23,
-      "end": 644.69,
-      "text": "no boo",
-      "words": [
+        },
         {
           "word": "no",
           "start": 644.23,
@@ -18103,8 +17563,8 @@
     {
       "id": 439,
       "start": 645.99,
-      "end": 646.65,
-      "text": "there's no party boy",
+      "end": 647.47,
+      "text": "there's no party boy Better know, don't try,",
       "words": [
         {
           "word": "there's",
@@ -18129,16 +17589,7 @@
           "start": 646.49,
           "end": 646.65,
           "probability": 0.9897125959396362
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 440,
-      "start": 646.65,
-      "end": 647.07,
-      "text": "Better know,",
-      "words": [
+        },
         {
           "word": "Better",
           "start": 646.65,
@@ -18150,16 +17601,7 @@
           "start": 646.87,
           "end": 647.07,
           "probability": 0.9958653450012207
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 441,
-      "start": 647.17,
-      "end": 647.47,
-      "text": "don't try,",
-      "words": [
+        },
         {
           "word": "don't",
           "start": 647.17,
@@ -18412,8 +17854,8 @@
     {
       "id": 448,
       "start": 655.35,
-      "end": 656.39,
-      "text": "Fully grown fritz major,",
+      "end": 657.03,
+      "text": "Fully grown fritz major, like laser",
       "words": [
         {
           "word": "Fully",
@@ -18438,16 +17880,7 @@
           "start": 656.07,
           "end": 656.39,
           "probability": 0.666093647480011
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 449,
-      "start": 656.61,
-      "end": 657.03,
-      "text": "like laser",
-      "words": [
+        },
         {
           "word": "like",
           "start": 656.61,
@@ -18466,8 +17899,8 @@
     {
       "id": 450,
       "start": 657.03,
-      "end": 658.65,
-      "text": "Them man are in a relegation battle",
+      "end": 659.05,
+      "text": "Them man are in a relegation battle Me,",
       "words": [
         {
           "word": "Them",
@@ -18510,16 +17943,7 @@
           "start": 658.33,
           "end": 658.65,
           "probability": 0.9744952321052551
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 451,
-      "start": 658.65,
-      "end": 659.05,
-      "text": "Me,",
-      "words": [
+        },
         {
           "word": "Me,",
           "start": 658.65,
@@ -18646,8 +18070,8 @@
     {
       "id": 454,
       "start": 662.49,
-      "end": 664.35,
-      "text": "Don't seem that long ago when my doctor told",
+      "end": 663.93,
+      "text": "Don't seem that long ago when my",
       "words": [
         {
           "word": "Don't",
@@ -18690,7 +18114,16 @@
           "start": 663.79,
           "end": 663.93,
           "probability": 0.9858422875404358
-        },
+        }
+      ],
+      "speaker": "Frisco"
+    },
+    {
+      "id": 455,
+      "start": 663.93,
+      "end": 664.53,
+      "text": "doctor told me",
+      "words": [
         {
           "word": "doctor",
           "start": 663.93,
@@ -18702,16 +18135,7 @@
           "start": 664.11,
           "end": 664.35,
           "probability": 0.9980509281158447
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 455,
-      "start": 664.35,
-      "end": 664.53,
-      "text": "me",
-      "words": [
+        },
         {
           "word": "me",
           "start": 664.35,
@@ -18787,8 +18211,8 @@
     {
       "id": 457,
       "start": 666.25,
-      "end": 667.15,
-      "text": "I don't wanna know,",
+      "end": 667.91,
+      "text": "I don't wanna know, I repeat,",
       "words": [
         {
           "word": "I",
@@ -18813,16 +18237,7 @@
           "start": 666.83,
           "end": 667.15,
           "probability": 0.994564414024353
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 458,
-      "start": 667.39,
-      "end": 667.91,
-      "text": "I repeat,",
-      "words": [
+        },
         {
           "word": "I",
           "start": 667.39,
@@ -18976,8 +18391,8 @@
     {
       "id": 462,
       "start": 672.51,
-      "end": 674.09,
-      "text": "And it ends and don't wanna go",
+      "end": 675.81,
+      "text": "And it ends and don't wanna go I'm major,",
       "words": [
         {
           "word": "And",
@@ -19020,16 +18435,7 @@
           "start": 673.55,
           "end": 674.09,
           "probability": 0.9969332218170166
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 463,
-      "start": 674.93,
-      "end": 675.81,
-      "text": "I'm major,",
-      "words": [
+        },
         {
           "word": "I'm",
           "start": 674.93,
@@ -19367,10 +18773,10 @@
       "speaker": "Frisco"
     },
     {
-      "id": 471,
+      "id": 472,
       "start": 687.73,
-      "end": 688.29,
-      "text": "Yo Jam",
+      "end": 690.09,
+      "text": "Yo Jam It all started",
       "words": [
         {
           "word": "Yo",
@@ -19383,16 +18789,7 @@
           "start": 687.91,
           "end": 688.29,
           "probability": 0.44665947556495667
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 472,
-      "start": 688.95,
-      "end": 690.09,
-      "text": "It all started",
-      "words": [
+        },
         {
           "word": "It",
           "start": 688.95,
@@ -19711,8 +19108,8 @@
     {
       "id": 479,
       "start": 700.33,
-      "end": 701.65,
-      "text": "Cause you wanna sit in my jazz,",
+      "end": 702.05,
+      "text": "Cause you wanna sit in my jazz, my world,",
       "words": [
         {
           "word": "Cause",
@@ -19755,16 +19152,7 @@
           "start": 701.47,
           "end": 701.65,
           "probability": 0.18255817890167236
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 480,
-      "start": 701.79,
-      "end": 702.05,
-      "text": "my world,",
-      "words": [
+        },
         {
           "word": "my",
           "start": 701.79,
@@ -19781,10 +19169,10 @@
       "speaker": "Jammer"
     },
     {
-      "id": 481,
+      "id": 482,
       "start": 702.21,
-      "end": 702.43,
-      "text": "my space",
+      "end": 704.17,
+      "text": "my space My time, my place, swad",
       "words": [
         {
           "word": "my",
@@ -19797,16 +19185,7 @@
           "start": 702.23,
           "end": 702.43,
           "probability": 0.9881622195243835
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 482,
-      "start": 702.43,
-      "end": 702.93,
-      "text": "My time,",
-      "words": [
+        },
         {
           "word": "My",
           "start": 702.43,
@@ -19818,16 +19197,7 @@
           "start": 702.71,
           "end": 702.93,
           "probability": 0.919127345085144
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 483,
-      "start": 702.97,
-      "end": 703.43,
-      "text": "my place,",
-      "words": [
+        },
         {
           "word": "my",
           "start": 702.97,
@@ -19839,16 +19209,7 @@
           "start": 703.09,
           "end": 703.43,
           "probability": 0.9958244562149048
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 484,
-      "start": 703.61,
-      "end": 704.17,
-      "text": "swad",
-      "words": [
+        },
         {
           "word": "swad",
           "start": 703.61,
@@ -19922,10 +19283,10 @@
       "speaker": "Jammer"
     },
     {
-      "id": 486,
+      "id": 487,
       "start": 706.09,
-      "end": 706.81,
-      "text": "take off",
+      "end": 708.11,
+      "text": "take off Blow up, no paper,",
       "words": [
         {
           "word": "take",
@@ -19938,16 +19299,7 @@
           "start": 706.43,
           "end": 706.81,
           "probability": 0.9621701240539551
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 487,
-      "start": 706.81,
-      "end": 707.41,
-      "text": "Blow up,",
-      "words": [
+        },
         {
           "word": "Blow",
           "start": 706.81,
@@ -19959,16 +19311,7 @@
           "start": 707.13,
           "end": 707.41,
           "probability": 0.9869500994682312
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 488,
-      "start": 707.59,
-      "end": 708.11,
-      "text": "no paper,",
-      "words": [
+        },
         {
           "word": "no",
           "start": 707.59,
@@ -20020,8 +19363,8 @@
     {
       "id": 490,
       "start": 709.03,
-      "end": 710.11,
-      "text": "But if it ain't no too sick,",
+      "end": 710.69,
+      "text": "But if it ain't no too sick, throw up",
       "words": [
         {
           "word": "But",
@@ -20064,16 +19407,7 @@
           "start": 709.95,
           "end": 710.11,
           "probability": 0.965477466583252
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 491,
-      "start": 710.25,
-      "end": 710.69,
-      "text": "throw up",
-      "words": [
+        },
         {
           "word": "throw",
           "start": 710.25,
@@ -20092,8 +19426,8 @@
     {
       "id": 492,
       "start": 710.69,
-      "end": 711.91,
-      "text": "I keep telling these pricks,",
+      "end": 712.45,
+      "text": "I keep telling these pricks, blow up",
       "words": [
         {
           "word": "I",
@@ -20124,16 +19458,7 @@
           "start": 711.59,
           "end": 711.91,
           "probability": 0.9268682301044464
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 493,
-      "start": 712.07,
-      "end": 712.45,
-      "text": "blow up",
-      "words": [
+        },
         {
           "word": "blow",
           "start": 712.07,
@@ -20152,8 +19477,8 @@
     {
       "id": 494,
       "start": 712.45,
-      "end": 713.45,
-      "text": "You can't sink my boat,",
+      "end": 713.93,
+      "text": "You can't sink my boat, I'm Noah",
       "words": [
         {
           "word": "You",
@@ -20184,16 +19509,7 @@
           "start": 713.27,
           "end": 713.45,
           "probability": 0.9885474443435669
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 495,
-      "start": 713.55,
-      "end": 713.93,
-      "text": "I'm Noah",
-      "words": [
+        },
         {
           "word": "I'm",
           "start": 713.55,
@@ -20795,26 +20111,17 @@
       "speaker": "Skepta"
     },
     {
-      "id": 507,
+      "id": 508,
       "start": 741.53,
-      "end": 741.99,
-      "text": "Yo,",
+      "end": 743.27,
+      "text": "Yo, the bad boys are back",
       "words": [
         {
           "word": "Yo,",
           "start": 741.53,
           "end": 741.99,
           "probability": 0.6582362055778503
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 508,
-      "start": 742.19,
-      "end": 743.27,
-      "text": "the bad boys are back",
-      "words": [
+        },
         {
           "word": "the",
           "start": 742.19,
@@ -21046,8 +20353,8 @@
     {
       "id": 514,
       "start": 748.77,
-      "end": 750.27,
-      "text": "Legion pull up the trowel",
+      "end": 750.61,
+      "text": "Legion pull up the trowel Shut up,",
       "words": [
         {
           "word": "Legion",
@@ -21078,16 +20385,7 @@
           "start": 749.71,
           "end": 750.27,
           "probability": 0.7526116172472636
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 515,
-      "start": 750.27,
-      "end": 750.61,
-      "text": "Shut up,",
-      "words": [
+        },
         {
           "word": "Shut",
           "start": 750.27,
@@ -21106,8 +20404,8 @@
     {
       "id": 516,
       "start": 750.61,
-      "end": 750.61,
-      "text": "I'm not a fucking idiot",
+      "end": 751.27,
+      "text": "I'm not a fucking idiot It's down,",
       "words": [
         {
           "word": "I'm",
@@ -21138,16 +20436,7 @@
           "start": 750.61,
           "end": 750.61,
           "probability": 0.02653549797832966
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 517,
-      "start": 750.61,
-      "end": 751.27,
-      "text": "It's down,",
-      "words": [
+        },
         {
           "word": "It's",
           "start": 750.61,
@@ -21317,10 +20606,10 @@
       "speaker": "Skepta"
     },
     {
-      "id": 521,
+      "id": 522,
       "start": 755.67,
-      "end": 756.47,
-      "text": "right now",
+      "end": 756.89,
+      "text": "right now Wow,",
       "words": [
         {
           "word": "right",
@@ -21333,16 +20622,7 @@
           "start": 755.99,
           "end": 756.47,
           "probability": 0.9682909846305847
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 522,
-      "start": 756.47,
-      "end": 756.89,
-      "text": "Wow,",
-      "words": [
+        },
         {
           "word": "Wow,",
           "start": 756.47,
@@ -21394,8 +20674,8 @@
     {
       "id": 524,
       "start": 758.19,
-      "end": 759.23,
-      "text": "and if you don't like it",
+      "end": 759.85,
+      "text": "and if you don't like it Lump it,",
       "words": [
         {
           "word": "and",
@@ -21432,16 +20712,7 @@
           "start": 758.97,
           "end": 759.23,
           "probability": 0.9965477585792542
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 525,
-      "start": 759.23,
-      "end": 759.85,
-      "text": "Lump it,",
-      "words": [
+        },
         {
           "word": "Lump",
           "start": 759.23,
@@ -21458,10 +20729,10 @@
       "speaker": "Skepta"
     },
     {
-      "id": 526,
+      "id": 527,
       "start": 760.01,
-      "end": 760.65,
-      "text": "bad boy",
+      "end": 761.49,
+      "text": "bad boy Just be the record,",
       "words": [
         {
           "word": "bad",
@@ -21474,16 +20745,7 @@
           "start": 760.17,
           "end": 760.65,
           "probability": 0.06570453196763992
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 527,
-      "start": 760.65,
-      "end": 761.49,
-      "text": "Just be the record,",
-      "words": [
+        },
         {
           "word": "Just",
           "start": 760.65,
@@ -21655,8 +20917,8 @@
     {
       "id": 531,
       "start": 766.15,
-      "end": 767.53,
-      "text": "me and Diddy got both hands on a big",
+      "end": 767.37,
+      "text": "me and Diddy got both hands on a",
       "words": [
         {
           "word": "me",
@@ -21705,22 +20967,22 @@
           "start": 767.25,
           "end": 767.37,
           "probability": 0.882518470287323
-        },
-        {
-          "word": "big",
-          "start": 767.37,
-          "end": 767.53,
-          "probability": 0.9752757549285889
         }
       ],
       "speaker": "Skepta"
     },
     {
       "id": 532,
-      "start": 767.53,
+      "start": 767.37,
       "end": 767.91,
-      "text": "red button",
+      "text": "big red button",
       "words": [
+        {
+          "word": "big",
+          "start": 767.37,
+          "end": 767.53,
+          "probability": 0.9752757549285889
+        },
         {
           "word": "red",
           "start": 767.53,
@@ -21739,8 +21001,8 @@
     {
       "id": 533,
       "start": 767.91,
-      "end": 770.09,
-      "text": "Just say the word and shut down the world",
+      "end": 769.33,
+      "text": "Just say the word and shut down",
       "words": [
         {
           "word": "Just",
@@ -21783,7 +21045,16 @@
           "start": 769.09,
           "end": 769.33,
           "probability": 0.9968922734260559
-        },
+        }
+      ],
+      "speaker": "Skepta"
+    },
+    {
+      "id": 534,
+      "start": 769.33,
+      "end": 770.57,
+      "text": "the world Wow,",
+      "words": [
         {
           "word": "the",
           "start": 769.33,
@@ -21795,16 +21066,7 @@
           "start": 769.57,
           "end": 770.09,
           "probability": 0.4895642399787903
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 534,
-      "start": 770.09,
-      "end": 770.57,
-      "text": "Wow,",
-      "words": [
+        },
         {
           "word": "Wow,",
           "start": 770.09,
@@ -21913,8 +21175,8 @@
     {
       "id": 537,
       "start": 773.37,
-      "end": 774.09,
-      "text": "I go hard mate,",
+      "end": 774.79,
+      "text": "I go hard mate, MC tap,",
       "words": [
         {
           "word": "I",
@@ -21939,16 +21201,7 @@
           "start": 773.95,
           "end": 774.09,
           "probability": 0.36714819073677063
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 538,
-      "start": 774.11,
-      "end": 774.79,
-      "text": "MC tap,",
-      "words": [
+        },
         {
           "word": "MC",
           "start": 774.11,
@@ -22096,8 +21349,8 @@
     {
       "id": 542,
       "start": 778.39,
-      "end": 780.03,
-      "text": "So violate and I'm liable to lash out",
+      "end": 782.95,
+      "text": "So violate and I'm liable to lash out Wow,",
       "words": [
         {
           "word": "So",
@@ -22146,16 +21399,7 @@
           "start": 779.87,
           "end": 780.03,
           "probability": 0.797010064125061
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 543,
-      "start": 782.55,
-      "end": 782.95,
-      "text": "Wow,",
-      "words": [
+        },
         {
           "word": "Wow,",
           "start": 782.55,
@@ -22264,8 +21508,8 @@
     {
       "id": 546,
       "start": 786.85,
-      "end": 787.61,
-      "text": "I go hard mate,",
+      "end": 788.25,
+      "text": "I go hard mate, MC tap,",
       "words": [
         {
           "word": "I",
@@ -22290,16 +21534,7 @@
           "start": 787.43,
           "end": 787.61,
           "probability": 0.0011135127861052752
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 547,
-      "start": 787.93,
-      "end": 788.25,
-      "text": "MC tap,",
-      "words": [
+        },
         {
           "word": "MC",
           "start": 787.93,
@@ -22609,8 +21844,8 @@
     {
       "id": 555,
       "start": 796.39,
-      "end": 797.23,
-      "text": "I'm gas now",
+      "end": 798.07,
+      "text": "I'm gas now Gas now,",
       "words": [
         {
           "word": "I'm",
@@ -22629,16 +21864,7 @@
           "start": 796.77,
           "end": 797.23,
           "probability": 0.9438381791114807
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 556,
-      "start": 797.23,
-      "end": 798.07,
-      "text": "Gas now,",
-      "words": [
+        },
         {
           "word": "Gas",
           "start": 797.23,
@@ -22786,8 +22012,8 @@
     {
       "id": 560,
       "start": 802.11,
-      "end": 803.79,
-      "text": "Presidential think it's that now",
+      "end": 804.27,
+      "text": "Presidential think it's that now Start slipping,",
       "words": [
         {
           "word": "Presidential",
@@ -22818,16 +22044,7 @@
           "start": 803.47,
           "end": 803.79,
           "probability": 0.9433713555335999
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 561,
-      "start": 803.79,
-      "end": 804.27,
-      "text": "Start slipping,",
-      "words": [
+        },
         {
           "word": "Start",
           "start": 803.79,
@@ -22952,10 +22169,10 @@
       "speaker": "Frisco"
     },
     {
-      "id": 564,
+      "id": 565,
       "start": 806.69,
-      "end": 807.09,
-      "text": "that foul",
+      "end": 808.67,
+      "text": "that foul My light skinned dog in the background",
       "words": [
         {
           "word": "that",
@@ -22968,16 +22185,7 @@
           "start": 806.91,
           "end": 807.09,
           "probability": 0.9764308333396912
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 565,
-      "start": 807.09,
-      "end": 808.67,
-      "text": "My light skinned dog in the background",
-      "words": [
+        },
         {
           "word": "My",
           "start": 807.09,
@@ -23087,41 +22295,23 @@
       "speaker": "Frisco"
     },
     {
-      "id": 567,
+      "id": 569,
       "start": 810.33,
-      "end": 810.63,
-      "text": "down",
+      "end": 812.13,
+      "text": "down Well, I will never back down",
       "words": [
         {
           "word": "down",
           "start": 810.33,
           "end": 810.63,
           "probability": 0.9909780025482178
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 568,
-      "start": 810.63,
-      "end": 811.13,
-      "text": "Well,",
-      "words": [
+        },
         {
           "word": "Well,",
           "start": 810.63,
           "end": 811.13,
           "probability": 0.5413055419921875
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 569,
-      "start": 811.23,
-      "end": 812.13,
-      "text": "I will never back down",
-      "words": [
+        },
         {
           "word": "I",
           "start": 811.23,
@@ -23248,8 +22438,8 @@
     {
       "id": 572,
       "start": 814.85,
-      "end": 815.45,
-      "text": "go get it",
+      "end": 816.51,
+      "text": "go get it Straight uncut, no edit,",
       "words": [
         {
           "word": "go",
@@ -23268,16 +22458,7 @@
           "start": 815.23,
           "end": 815.45,
           "probability": 0.9933634996414185
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 573,
-      "start": 815.45,
-      "end": 816.05,
-      "text": "Straight uncut,",
-      "words": [
+        },
         {
           "word": "Straight",
           "start": 815.45,
@@ -23289,16 +22470,7 @@
           "start": 815.67,
           "end": 816.05,
           "probability": 0.8272630572319031
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 574,
-      "start": 816.19,
-      "end": 816.51,
-      "text": "no edit,",
-      "words": [
+        },
         {
           "word": "no",
           "start": 816.19,
@@ -23762,10 +22934,10 @@
       "speaker": "Frisco"
     },
     {
-      "id": 586,
+      "id": 587,
       "start": 828.87,
-      "end": 829.55,
-      "text": "Capital F,",
+      "end": 830.47,
+      "text": "Capital F, the R's moving again",
       "words": [
         {
           "word": "Capital",
@@ -23778,16 +22950,7 @@
           "start": 829.29,
           "end": 829.55,
           "probability": 0.9552769660949707
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 587,
-      "start": 829.55,
-      "end": 830.47,
-      "text": "the R's moving again",
-      "words": [
+        },
         {
           "word": "the",
           "start": 829.55,
@@ -24181,8 +23344,8 @@
     {
       "id": 597,
       "start": 841.59,
-      "end": 842.69,
-      "text": "ain't got one shell",
+      "end": 844.27,
+      "text": "ain't got one shell Logan!",
       "words": [
         {
           "word": "ain't",
@@ -24207,16 +23370,7 @@
           "start": 842.39,
           "end": 842.69,
           "probability": 0.5156259536743164
-        }
-      ],
-      "speaker": "Shorty"
-    },
-    {
-      "id": 598,
-      "start": 843.87,
-      "end": 844.27,
-      "text": "Logan!",
-      "words": [
+        },
         {
           "word": "Logan!",
           "start": 843.87,
@@ -24229,8 +23383,8 @@
     {
       "id": 599,
       "start": 845.39,
-      "end": 846.43,
-      "text": "I want some of this as well,",
+      "end": 846.87,
+      "text": "I want some of this as well, Shorty",
       "words": [
         {
           "word": "I",
@@ -24273,16 +23427,7 @@
           "start": 846.25,
           "end": 846.43,
           "probability": 0.9718402028083801
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 600,
-      "start": 846.63,
-      "end": 846.87,
-      "text": "Shorty",
-      "words": [
+        },
         {
           "word": "Shorty",
           "start": 846.63,
@@ -24314,10 +23459,10 @@
       "speaker": "Shorty"
     },
     {
-      "id": 602,
+      "id": 603,
       "start": 847.63,
-      "end": 847.93,
-      "text": "let's go,",
+      "end": 848.79,
+      "text": "let's go, let's go",
       "words": [
         {
           "word": "let's",
@@ -24330,16 +23475,7 @@
           "start": 847.75,
           "end": 847.93,
           "probability": 0.997395396232605
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 603,
-      "start": 847.93,
-      "end": 848.79,
-      "text": "let's go",
-      "words": [
+        },
         {
           "word": "let's",
           "start": 847.93,
@@ -24383,26 +23519,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 605,
+      "id": 606,
       "start": 849.97,
-      "end": 850.39,
-      "text": "Yo",
+      "end": 853.21,
+      "text": "Yo Nuff man wanna talk about strats",
       "words": [
         {
           "word": "Yo",
           "start": 849.97,
           "end": 850.39,
           "probability": 0.7928423285484314
-        }
-      ],
-      "speaker": "Shorty"
-    },
-    {
-      "id": 606,
-      "start": 851.15,
-      "end": 853.21,
-      "text": "Nuff man wanna talk about strats",
-      "words": [
+        },
         {
           "word": "Nuff",
           "start": 851.15,
@@ -24763,8 +23890,8 @@
     {
       "id": 615,
       "start": 862.13,
-      "end": 862.81,
-      "text": "ain't seen one shell",
+      "end": 863.65,
+      "text": "ain't seen one shell Brainwashed man,",
       "words": [
         {
           "word": "ain't",
@@ -24789,16 +23916,7 @@
           "start": 862.59,
           "end": 862.81,
           "probability": 0.4301886558532715
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 616,
-      "start": 862.81,
-      "end": 863.65,
-      "text": "Brainwashed man,",
-      "words": [
+        },
         {
           "word": "Brainwashed",
           "start": 862.81,
@@ -26056,8 +25174,8 @@
     {
       "id": 646,
       "start": 903.33,
-      "end": 905.33,
-      "text": "Let off my neck shot like Marco",
+      "end": 906.85,
+      "text": "Let off my neck shot like Marco Van Basten,",
       "words": [
         {
           "word": "Let",
@@ -26100,16 +25218,7 @@
           "start": 904.51,
           "end": 905.33,
           "probability": 0.5032020211219788
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 647,
-      "start": 906.05,
-      "end": 906.85,
-      "text": "Van Basten,",
-      "words": [
+        },
         {
           "word": "Van",
           "start": 906.05,
@@ -26669,10 +25778,10 @@
       "speaker": "Jammer"
     },
     {
-      "id": 659,
+      "id": 660,
       "start": 926.61,
-      "end": 927.27,
-      "text": "private caller",
+      "end": 928.93,
+      "text": "private caller So I just told my dealer",
       "words": [
         {
           "word": "private",
@@ -26685,16 +25794,7 @@
           "start": 926.91,
           "end": 927.27,
           "probability": 0.9647600650787354
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 660,
-      "start": 927.27,
-      "end": 928.93,
-      "text": "So I just told my dealer",
-      "words": [
+        },
         {
           "word": "So",
           "start": 927.27,
@@ -27394,8 +26494,8 @@
     {
       "id": 674,
       "start": 951.11,
-      "end": 952.55,
-      "text": "And he doesn't wanna say that I got a",
+      "end": 952.33,
+      "text": "And he doesn't wanna say that I",
       "words": [
         {
           "word": "And",
@@ -27438,7 +26538,16 @@
           "start": 952.21,
           "end": 952.33,
           "probability": 0.554580807685852
-        },
+        }
+      ],
+      "speaker": "Jammer"
+    },
+    {
+      "id": 675,
+      "start": 952.33,
+      "end": 952.69,
+      "text": "got a small",
+      "words": [
         {
           "word": "got",
           "start": 952.33,
@@ -27450,16 +26559,7 @@
           "start": 952.41,
           "end": 952.55,
           "probability": 0.7328909039497375
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 675,
-      "start": 952.55,
-      "end": 952.69,
-      "text": "small",
-      "words": [
+        },
         {
           "word": "small",
           "start": 952.55,
@@ -27596,10 +26696,10 @@
       "speaker": "Jammer"
     },
     {
-      "id": 678,
+      "id": 679,
       "start": 956.33,
-      "end": 956.77,
-      "text": "not flattered",
+      "end": 959.67,
+      "text": "not flattered The DJ's really For real,",
       "words": [
         {
           "word": "not",
@@ -27612,16 +26712,7 @@
           "start": 956.57,
           "end": 956.77,
           "probability": 0.39716050773859024
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 679,
-      "start": 956.77,
-      "end": 957.97,
-      "text": "The DJ's really",
-      "words": [
+        },
         {
           "word": "The",
           "start": 956.77,
@@ -27639,16 +26730,7 @@
           "start": 957.97,
           "end": 957.97,
           "probability": 0.399982750415802
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 680,
-      "start": 957.97,
-      "end": 959.67,
-      "text": "For real,",
-      "words": [
+        },
         {
           "word": "For",
           "start": 957.97,
@@ -28271,26 +27353,17 @@
       "speaker": "JME"
     },
     {
-      "id": 693,
+      "id": 694,
       "start": 979.79,
-      "end": 980.01,
-      "text": "goes",
+      "end": 981.69,
+      "text": "goes I don't care what anyone's saying",
       "words": [
         {
           "word": "goes",
           "start": 979.79,
           "end": 980.01,
           "probability": 0.9919330477714539
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 694,
-      "start": 980.01,
-      "end": 981.69,
-      "text": "I don't care what anyone's saying",
-      "words": [
+        },
         {
           "word": "I",
           "start": 980.01,
@@ -28807,8 +27880,8 @@
     {
       "id": 705,
       "start": 998.21,
-      "end": 1000.03,
-      "text": "You get big upper cuts like footsie",
+      "end": 1000.65,
+      "text": "You get big upper cuts like footsie I'm Mac,",
       "words": [
         {
           "word": "You",
@@ -28851,16 +27924,7 @@
           "start": 999.47,
           "end": 1000.03,
           "probability": 0.7393542428811392
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 706,
-      "start": 1000.03,
-      "end": 1000.65,
-      "text": "I'm Mac,",
-      "words": [
+        },
         {
           "word": "I'm",
           "start": 1000.03,
@@ -29225,26 +28289,17 @@
       "speaker": "JME"
     },
     {
-      "id": 715,
+      "id": 716,
       "start": 1013.03,
-      "end": 1013.39,
-      "text": "Serious",
+      "end": 1015.01,
+      "text": "Serious Man wanna pray for my damn pool safe",
       "words": [
         {
           "word": "Serious",
           "start": 1013.03,
           "end": 1013.39,
           "probability": 0.49006646778434515
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 716,
-      "start": 1013.39,
-      "end": 1015.01,
-      "text": "Man wanna pray for my damn pool safe",
-      "words": [
+        },
         {
           "word": "Man",
           "start": 1013.39,
@@ -29350,8 +28405,8 @@
     {
       "id": 718,
       "start": 1016.19,
-      "end": 1017.57,
-      "text": "Give me the rhythm and let me get grime",
+      "end": 1017.35,
+      "text": "Give me the rhythm and let me get",
       "words": [
         {
           "word": "Give",
@@ -29400,22 +28455,22 @@
           "start": 1017.13,
           "end": 1017.35,
           "probability": 0.9946479201316833
-        },
-        {
-          "word": "grime",
-          "start": 1017.35,
-          "end": 1017.57,
-          "probability": 0.9050579965114594
         }
       ],
       "speaker": "Frisco"
     },
     {
       "id": 719,
-      "start": 1017.57,
+      "start": 1017.35,
       "end": 1017.89,
-      "text": "on them",
+      "text": "grime on them",
       "words": [
+        {
+          "word": "grime",
+          "start": 1017.35,
+          "end": 1017.57,
+          "probability": 0.9050579965114594
+        },
         {
           "word": "on",
           "start": 1017.57,
@@ -29495,26 +28550,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 721,
+      "id": 722,
       "start": 1019.49,
-      "end": 1019.63,
-      "text": "them",
+      "end": 1021.33,
+      "text": "them New flow let me fire one again",
       "words": [
         {
           "word": "them",
           "start": 1019.49,
           "end": 1019.63,
           "probability": 0.9881332516670227
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 722,
-      "start": 1019.63,
-      "end": 1021.33,
-      "text": "New flow let me fire one again",
-      "words": [
+        },
         {
           "word": "New",
           "start": 1019.63,
@@ -29563,8 +28609,8 @@
     {
       "id": 723,
       "start": 1021.33,
-      "end": 1022.81,
-      "text": "I ain't gonna force it but if you force",
+      "end": 1022.49,
+      "text": "I ain't gonna force it but if",
       "words": [
         {
           "word": "I",
@@ -29607,7 +28653,16 @@
           "start": 1022.33,
           "end": 1022.49,
           "probability": 0.9797558784484863
-        },
+        }
+      ],
+      "speaker": "Frisco"
+    },
+    {
+      "id": 724,
+      "start": 1022.49,
+      "end": 1022.97,
+      "text": "you force it",
+      "words": [
         {
           "word": "you",
           "start": 1022.49,
@@ -29619,16 +28674,7 @@
           "start": 1022.67,
           "end": 1022.81,
           "probability": 0.9806298613548279
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 724,
-      "start": 1022.81,
-      "end": 1022.97,
-      "text": "it",
-      "words": [
+        },
         {
           "word": "it",
           "start": 1022.81,
@@ -29702,26 +28748,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 726,
+      "id": 727,
       "start": 1024.65,
-      "end": 1025.21,
-      "text": "forklift",
+      "end": 1026.33,
+      "text": "forklift So mind that you're speaking to me",
       "words": [
         {
           "word": "forklift",
           "start": 1024.65,
           "end": 1025.21,
           "probability": 0.9078447024027506
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 727,
-      "start": 1025.21,
-      "end": 1026.33,
-      "text": "So mind that you're speaking to me",
-      "words": [
+        },
         {
           "word": "So",
           "start": 1025.21,
@@ -29981,26 +29018,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 733,
+      "id": 734,
       "start": 1031.25,
-      "end": 1031.55,
-      "text": "them",
+      "end": 1032.31,
+      "text": "them Lose my sight,",
       "words": [
         {
           "word": "them",
           "start": 1031.25,
           "end": 1031.55,
           "probability": 0.8143700361251831
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 734,
-      "start": 1031.55,
-      "end": 1032.31,
-      "text": "Lose my sight,",
-      "words": [
+        },
         {
           "word": "Lose",
           "start": 1031.55,
@@ -30187,8 +29215,8 @@
     {
       "id": 739,
       "start": 1036.45,
-      "end": 1038.35,
-      "text": "Sometimes I wanna take back mine from them",
+      "end": 1038.77,
+      "text": "Sometimes I wanna take back mine from them Miner,",
       "words": [
         {
           "word": "Sometimes",
@@ -30237,16 +29265,7 @@
           "start": 1037.97,
           "end": 1038.35,
           "probability": 0.9953023195266724
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 740,
-      "start": 1038.35,
-      "end": 1038.77,
-      "text": "Miner,",
-      "words": [
+        },
         {
           "word": "Miner,",
           "start": 1038.35,
@@ -30259,8 +29278,8 @@
     {
       "id": 741,
       "start": 1038.87,
-      "end": 1040.03,
-      "text": "what's a new style on me",
+      "end": 1040.39,
+      "text": "what's a new style on me Serious",
       "words": [
         {
           "word": "what's",
@@ -30297,16 +29316,7 @@
           "start": 1039.71,
           "end": 1040.03,
           "probability": 0.3581306040287018
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 742,
-      "start": 1040.03,
-      "end": 1040.39,
-      "text": "Serious",
-      "words": [
+        },
         {
           "word": "Serious",
           "start": 1040.03,
@@ -30317,10 +29327,10 @@
       "speaker": "Frisco"
     },
     {
-      "id": 743,
+      "id": 744,
       "start": 1041.25,
-      "end": 1041.97,
-      "text": "Total package,",
+      "end": 1043.49,
+      "text": "Total package, F in them in Buckingham Palace",
       "words": [
         {
           "word": "Total",
@@ -30333,16 +29343,7 @@
           "start": 1041.61,
           "end": 1041.97,
           "probability": 0.9644010066986084
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 744,
-      "start": 1042.17,
-      "end": 1043.49,
-      "text": "F in them in Buckingham Palace",
-      "words": [
+        },
         {
           "word": "F",
           "start": 1042.17,
@@ -30694,8 +29695,8 @@
     {
       "id": 752,
       "start": 1052.53,
-      "end": 1053.63,
-      "text": "Like Prada trainers",
+      "end": 1054.51,
+      "text": "Like Prada trainers New money,",
       "words": [
         {
           "word": "Like",
@@ -30714,16 +29715,7 @@
           "start": 1053.17,
           "end": 1053.63,
           "probability": 0.711017906665802
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 753,
-      "start": 1053.63,
-      "end": 1054.51,
-      "text": "New money,",
-      "words": [
+        },
         {
           "word": "New",
           "start": 1053.63,
@@ -30893,26 +29885,17 @@
       "speaker": "Skepta"
     },
     {
-      "id": 757,
+      "id": 758,
       "start": 1058.53,
-      "end": 1058.81,
-      "text": "birthday",
+      "end": 1061.19,
+      "text": "birthday Cause you ain't got no direction No future,",
       "words": [
         {
           "word": "birthday",
           "start": 1058.53,
           "end": 1058.81,
           "probability": 0.9854846596717834
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 758,
-      "start": 1058.81,
-      "end": 1060.41,
-      "text": "Cause you ain't got no direction",
-      "words": [
+        },
         {
           "word": "Cause",
           "start": 1058.81,
@@ -30948,16 +29931,7 @@
           "start": 1059.73,
           "end": 1060.41,
           "probability": 0.8133549094200134
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 759,
-      "start": 1060.41,
-      "end": 1061.19,
-      "text": "No future,",
-      "words": [
+        },
         {
           "word": "No",
           "start": 1060.41,
@@ -30974,10 +29948,10 @@
       "speaker": "Skepta"
     },
     {
-      "id": 760,
+      "id": 761,
       "start": 1061.45,
-      "end": 1061.99,
-      "text": "no plans",
+      "end": 1063.65,
+      "text": "no plans That's why you get air from friends",
       "words": [
         {
           "word": "no",
@@ -30990,16 +29964,7 @@
           "start": 1061.63,
           "end": 1061.99,
           "probability": 0.9941703081130981
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 761,
-      "start": 1061.99,
-      "end": 1063.65,
-      "text": "That's why you get air from friends",
-      "words": [
+        },
         {
           "word": "That's",
           "start": 1061.99,
@@ -31174,8 +30139,8 @@
     {
       "id": 764,
       "start": 1066.15,
-      "end": 1067.09,
-      "text": "the 28 grand",
+      "end": 1068.01,
+      "text": "the 28 grand Bounce",
       "words": [
         {
           "word": "the",
@@ -31194,16 +30159,7 @@
           "start": 1066.71,
           "end": 1067.09,
           "probability": 0.5854170918464661
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 765,
-      "start": 1067.65,
-      "end": 1068.01,
-      "text": "Bounce",
-      "words": [
+        },
         {
           "word": "Bounce",
           "start": 1067.65,
@@ -31214,26 +30170,17 @@
       "speaker": "Skepta"
     },
     {
-      "id": 766,
+      "id": 767,
       "start": 1068.85,
-      "end": 1069.21,
-      "text": "Bounce",
+      "end": 1071.55,
+      "text": "Bounce Bounce",
       "words": [
         {
           "word": "Bounce",
           "start": 1068.85,
           "end": 1069.21,
           "probability": 0.5741925835609436
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 767,
-      "start": 1071.19,
-      "end": 1071.55,
-      "text": "Bounce",
-      "words": [
+        },
         {
           "word": "Bounce",
           "start": 1071.19,
@@ -31244,26 +30191,17 @@
       "speaker": "unknown"
     },
     {
-      "id": 768,
+      "id": 769,
       "start": 1072.71,
-      "end": 1073.07,
-      "text": "Logan",
+      "end": 1075.93,
+      "text": "Logan Legolo",
       "words": [
         {
           "word": "Logan",
           "start": 1072.71,
           "end": 1073.07,
           "probability": 0.4654169976711273
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 769,
-      "start": 1075.57,
-      "end": 1075.93,
-      "text": "Legolo",
-      "words": [
+        },
         {
           "word": "Legolo",
           "start": 1075.57,
@@ -31303,8 +30241,8 @@
     {
       "id": 771,
       "start": 1079.25,
-      "end": 1080.43,
-      "text": "Will I hide?",
+      "end": 1085.77,
+      "text": "Will I hide? Damn Ah",
       "words": [
         {
           "word": "Will",
@@ -31323,31 +30261,13 @@
           "start": 1079.89,
           "end": 1080.43,
           "probability": 0.13414283096790314
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 772,
-      "start": 1081.83,
-      "end": 1082.23,
-      "text": "Damn",
-      "words": [
+        },
         {
           "word": "Damn",
           "start": 1081.83,
           "end": 1082.23,
           "probability": 0.5599251985549927
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 773,
-      "start": 1085.37,
-      "end": 1085.77,
-      "text": "Ah",
-      "words": [
+        },
         {
           "word": "Ah",
           "start": 1085.37,
@@ -31642,8 +30562,8 @@
     {
       "id": 782,
       "start": 1099.25,
-      "end": 1100.77,
-      "text": "Girls wanna come round the back and swear to",
+      "end": 1100.47,
+      "text": "Girls wanna come round the back and",
       "words": [
         {
           "word": "Girls",
@@ -31686,7 +30606,16 @@
           "start": 1100.31,
           "end": 1100.47,
           "probability": 0.3209187388420105
-        },
+        }
+      ],
+      "speaker": "Jammer"
+    },
+    {
+      "id": 783,
+      "start": 1100.47,
+      "end": 1100.97,
+      "text": "swear to man",
+      "words": [
         {
           "word": "swear",
           "start": 1100.47,
@@ -31698,16 +30627,7 @@
           "start": 1100.63,
           "end": 1100.77,
           "probability": 0.3696202337741852
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 783,
-      "start": 1100.77,
-      "end": 1100.97,
-      "text": "man",
-      "words": [
+        },
         {
           "word": "man",
           "start": 1100.77,
@@ -31936,8 +30856,8 @@
     {
       "id": 788,
       "start": 1107.41,
-      "end": 1108.45,
-      "text": "I'm like wow,",
+      "end": 1108.93,
+      "text": "I'm like wow, who's that?",
       "words": [
         {
           "word": "I'm",
@@ -31956,16 +30876,7 @@
           "start": 1108.03,
           "end": 1108.45,
           "probability": 0.7603939175605774
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 789,
-      "start": 1108.67,
-      "end": 1108.93,
-      "text": "who's that?",
-      "words": [
+        },
         {
           "word": "who's",
           "start": 1108.67,
@@ -32207,10 +31118,10 @@
       "speaker": "Jammer"
     },
     {
-      "id": 795,
+      "id": 796,
       "start": 1117.85,
-      "end": 1118.51,
-      "text": "Michael man,",
+      "end": 1119.37,
+      "text": "Michael man, kill it off fast",
       "words": [
         {
           "word": "Michael",
@@ -32223,16 +31134,7 @@
           "start": 1118.21,
           "end": 1118.51,
           "probability": 0.9937095642089844
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 796,
-      "start": 1118.73,
-      "end": 1119.37,
-      "text": "kill it off fast",
-      "words": [
+        },
         {
           "word": "kill",
           "start": 1118.73,
@@ -32296,8 +31198,8 @@
     {
       "id": 798,
       "start": 1120.73,
-      "end": 1122.37,
-      "text": "I want pounds,",
+      "end": 1122.85,
+      "text": "I want pounds, pennies,",
       "words": [
         {
           "word": "I",
@@ -32316,16 +31218,7 @@
           "start": 1122.01,
           "end": 1122.37,
           "probability": 0.9812684655189514
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 799,
-      "start": 1122.53,
-      "end": 1122.85,
-      "text": "pennies,",
-      "words": [
+        },
         {
           "word": "pennies,",
           "start": 1122.53,
@@ -32497,8 +31390,8 @@
     {
       "id": 803,
       "start": 1127.97,
-      "end": 1129.49,
-      "text": "Prang outing when miles in the deli",
+      "end": 1129.91,
+      "text": "Prang outing when miles in the deli B .B.",
       "words": [
         {
           "word": "Prang",
@@ -32541,16 +31434,7 @@
           "start": 1129.25,
           "end": 1129.49,
           "probability": 0.6304520815610886
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 804,
-      "start": 1129.49,
-      "end": 1129.91,
-      "text": "B .B.",
-      "words": [
+        },
         {
           "word": "B",
           "start": 1129.49,
@@ -33005,10 +31889,10 @@
       "speaker": "Jammer"
     },
     {
-      "id": 815,
+      "id": 816,
       "start": 1147.49,
-      "end": 1147.79,
-      "text": "Shoot it!",
+      "end": 1148.21,
+      "text": "Shoot it! Yo,",
       "words": [
         {
           "word": "Shoot",
@@ -33021,16 +31905,7 @@
           "start": 1147.73,
           "end": 1147.79,
           "probability": 0.7939791679382324
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 816,
-      "start": 1148.21,
-      "end": 1148.21,
-      "text": "Yo,",
-      "words": [
+        },
         {
           "word": "Yo,",
           "start": 1148.21,
@@ -34103,26 +32978,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 845,
+      "id": 846,
       "start": 1179.53,
-      "end": 1179.77,
-      "text": "pole",
+      "end": 1181.37,
+      "text": "pole Top corner and I look at the pole",
       "words": [
         {
           "word": "pole",
           "start": 1179.53,
           "end": 1179.77,
           "probability": 0.5218819379806519
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 846,
-      "start": 1179.77,
-      "end": 1181.37,
-      "text": "Top corner and I look at the pole",
-      "words": [
+        },
         {
           "word": "Top",
           "start": 1179.77,
@@ -34345,8 +33211,8 @@
     {
       "id": 851,
       "start": 1186.51,
-      "end": 1188.65,
-      "text": "Henny for the tops but I can't wait",
+      "end": 1189.47,
+      "text": "Henny for the tops but I can't wait No,",
       "words": [
         {
           "word": "Henny",
@@ -34395,16 +33261,7 @@
           "start": 1187.93,
           "end": 1188.65,
           "probability": 0.9955254197120667
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 852,
-      "start": 1189.07,
-      "end": 1189.47,
-      "text": "No,",
-      "words": [
+        },
         {
           "word": "No,",
           "start": 1189.07,
@@ -34562,26 +33419,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 856,
+      "id": 857,
       "start": 1194.07,
-      "end": 1194.51,
-      "text": "Myth,",
+      "end": 1195.61,
+      "text": "Myth, that's all a fairy dream",
       "words": [
         {
           "word": "Myth,",
           "start": 1194.07,
           "end": 1194.51,
           "probability": 0.9481061697006226
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 857,
-      "start": 1194.71,
-      "end": 1195.61,
-      "text": "that's all a fairy dream",
-      "words": [
+        },
         {
           "word": "that's",
           "start": 1194.71,
@@ -35308,8 +34156,8 @@
     {
       "id": 876,
       "start": 1214.01,
-      "end": 1215.27,
-      "text": "I stay lyrically sick,",
+      "end": 1215.57,
+      "text": "I stay lyrically sick, vomit",
       "words": [
         {
           "word": "I",
@@ -35334,16 +34182,7 @@
           "start": 1214.85,
           "end": 1215.27,
           "probability": 0.9884117245674133
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 877,
-      "start": 1215.35,
-      "end": 1215.57,
-      "text": "vomit",
-      "words": [
+        },
         {
           "word": "vomit",
           "start": 1215.35,
@@ -35503,8 +34342,8 @@
     {
       "id": 881,
       "start": 1220.97,
-      "end": 1221.97,
-      "text": "That temper I'm shouting,",
+      "end": 1223.01,
+      "text": "That temper I'm shouting, Ss",
       "words": [
         {
           "word": "That",
@@ -35529,16 +34368,7 @@
           "start": 1221.73,
           "end": 1221.97,
           "probability": 0.9596145749092102
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 882,
-      "start": 1222.65,
-      "end": 1223.01,
-      "text": "Ss",
-      "words": [
+        },
         {
           "word": "Ss",
           "start": 1222.65,
@@ -35695,8 +34525,8 @@
     {
       "id": 887,
       "start": 1227.37,
-      "end": 1228.79,
-      "text": "That's got the world scared of a man in",
+      "end": 1228.61,
+      "text": "That's got the world scared of a man",
       "words": [
         {
           "word": "That's",
@@ -35745,22 +34575,22 @@
           "start": 1228.49,
           "end": 1228.61,
           "probability": 0.9870758652687073
-        },
-        {
-          "word": "in",
-          "start": 1228.61,
-          "end": 1228.79,
-          "probability": 0.9910507202148438
         }
       ],
       "speaker": "Skepta"
     },
     {
       "id": 888,
-      "start": 1228.79,
+      "start": 1228.61,
       "end": 1229.47,
-      "text": "a turban",
+      "text": "in a turban",
       "words": [
+        {
+          "word": "in",
+          "start": 1228.61,
+          "end": 1228.79,
+          "probability": 0.9910507202148438
+        },
         {
           "word": "a",
           "start": 1228.79,
@@ -36202,8 +35032,8 @@
     {
       "id": 898,
       "start": 1240.85,
-      "end": 1242.21,
-      "text": "I'm laughing out loud so much",
+      "end": 1242.81,
+      "text": "I'm laughing out loud so much LUL",
       "words": [
         {
           "word": "I'm",
@@ -36240,16 +35070,7 @@
           "start": 1241.97,
           "end": 1242.21,
           "probability": 0.9964266419410706
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 899,
-      "start": 1242.21,
-      "end": 1242.81,
-      "text": "LUL",
-      "words": [
+        },
         {
           "word": "LUL",
           "start": 1242.21,
@@ -36379,8 +35200,8 @@
     {
       "id": 903,
       "start": 1267.99,
-      "end": 1270.09,
-      "text": "Look on man ting like shredder and crack",
+      "end": 1270.67,
+      "text": "Look on man ting like shredder and crack Bop,",
       "words": [
         {
           "word": "Look",
@@ -36429,16 +35250,7 @@
           "start": 1269.49,
           "end": 1270.09,
           "probability": 0.3377707898616791
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 904,
-      "start": 1270.09,
-      "end": 1270.67,
-      "text": "Bop,",
-      "words": [
+        },
         {
           "word": "Bop,",
           "start": 1270.09,
@@ -36449,26 +35261,17 @@
       "speaker": "JME"
     },
     {
-      "id": 905,
+      "id": 906,
       "start": 1270.75,
-      "end": 1271.03,
-      "text": "bop,",
+      "end": 1272.61,
+      "text": "bop, when I'm on I'ma come like an intervention",
       "words": [
         {
           "word": "bop,",
           "start": 1270.75,
           "end": 1271.03,
           "probability": 0.904144674539566
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 906,
-      "start": 1271.19,
-      "end": 1272.61,
-      "text": "when I'm on I'ma come like an intervention",
-      "words": [
+        },
         {
           "word": "when",
           "start": 1271.19,
@@ -36521,10 +35324,10 @@
       "speaker": "JME"
     },
     {
-      "id": 907,
+      "id": 908,
       "start": 1272.61,
-      "end": 1273.51,
-      "text": "Silent sniper,",
+      "end": 1275.05,
+      "text": "Silent sniper, full detention No silence,",
       "words": [
         {
           "word": "Silent",
@@ -36537,16 +35340,7 @@
           "start": 1273.17,
           "end": 1273.51,
           "probability": 0.9364637136459351
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 908,
-      "start": 1273.63,
-      "end": 1274.27,
-      "text": "full detention",
-      "words": [
+        },
         {
           "word": "full",
           "start": 1273.63,
@@ -36558,16 +35352,7 @@
           "start": 1273.79,
           "end": 1274.27,
           "probability": 0.5962439775466919
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 909,
-      "start": 1274.27,
-      "end": 1275.05,
-      "text": "No silence,",
-      "words": [
+        },
         {
           "word": "No",
           "start": 1274.27,
@@ -36958,8 +35743,8 @@
     {
       "id": 920,
       "start": 1287.49,
-      "end": 1289.45,
-      "text": "In that itch that's what I'm retention",
+      "end": 1290.07,
+      "text": "In that itch that's what I'm retention Yo,",
       "words": [
         {
           "word": "In",
@@ -37002,16 +35787,7 @@
           "start": 1289.05,
           "end": 1289.45,
           "probability": 0.41797760128974915
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 921,
-      "start": 1289.45,
-      "end": 1290.07,
-      "text": "Yo,",
-      "words": [
+        },
         {
           "word": "Yo,",
           "start": 1289.45,
@@ -37063,8 +35839,8 @@
     {
       "id": 923,
       "start": 1292.65,
-      "end": 1293.83,
-      "text": "Boy better know",
+      "end": 1297.49,
+      "text": "Boy better know I'm joining Alright, alright, alright",
       "words": [
         {
           "word": "Boy",
@@ -37083,16 +35859,7 @@
           "start": 1293.33,
           "end": 1293.83,
           "probability": 0.9261079430580139
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 924,
-      "start": 1295.63,
-      "end": 1296.15,
-      "text": "I'm joining",
-      "words": [
+        },
         {
           "word": "I'm",
           "start": 1295.63,
@@ -37104,46 +35871,19 @@
           "start": 1296.03,
           "end": 1296.15,
           "probability": 0.14313161373138428
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 925,
-      "start": 1296.15,
-      "end": 1296.27,
-      "text": "Alright,",
-      "words": [
+        },
         {
           "word": "Alright,",
           "start": 1296.15,
           "end": 1296.27,
           "probability": 0.032058682292699814
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 926,
-      "start": 1296.27,
-      "end": 1296.77,
-      "text": "alright,",
-      "words": [
+        },
         {
           "word": "alright,",
           "start": 1296.27,
           "end": 1296.77,
           "probability": 0.9533429145812988
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 927,
-      "start": 1296.77,
-      "end": 1297.49,
-      "text": "alright",
-      "words": [
+        },
         {
           "word": "alright",
           "start": 1296.77,
@@ -37156,8 +35896,8 @@
     {
       "id": 928,
       "start": 1299.65,
-      "end": 1301.33,
-      "text": "It's getting hot in here man",
+      "end": 1303.25,
+      "text": "It's getting hot in here man Yeah Ay",
       "words": [
         {
           "word": "It's",
@@ -37194,31 +35934,13 @@
           "start": 1301.11,
           "end": 1301.33,
           "probability": 0.6762005090713501
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 929,
-      "start": 1301.33,
-      "end": 1301.93,
-      "text": "Yeah",
-      "words": [
+        },
         {
           "word": "Yeah",
           "start": 1301.33,
           "end": 1301.93,
           "probability": 0.16847674548625946
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 930,
-      "start": 1302.85,
-      "end": 1303.25,
-      "text": "Ay",
-      "words": [
+        },
         {
           "word": "Ay",
           "start": 1302.85,
@@ -37540,8 +36262,8 @@
     {
       "id": 938,
       "start": 1312.41,
-      "end": 1312.97,
-      "text": "To no one,",
+      "end": 1313.95,
+      "text": "To no one, Frisco certified",
       "words": [
         {
           "word": "To",
@@ -37560,16 +36282,7 @@
           "start": 1312.87,
           "end": 1312.97,
           "probability": 0.9284264445304871
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 939,
-      "start": 1313.15,
-      "end": 1313.95,
-      "text": "Frisco certified",
-      "words": [
+        },
         {
           "word": "Frisco",
           "start": 1313.15,
@@ -37970,26 +36683,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 948,
+      "id": 949,
       "start": 1324.03,
-      "end": 1324.33,
-      "text": "side",
+      "end": 1325.03,
+      "text": "side Grime can't die,",
       "words": [
         {
           "word": "side",
           "start": 1324.03,
           "end": 1324.33,
           "probability": 0.5873339772224426
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 949,
-      "start": 1324.33,
-      "end": 1325.03,
-      "text": "Grime can't die,",
-      "words": [
+        },
         {
           "word": "Grime",
           "start": 1324.33,
@@ -38312,41 +37016,23 @@
       "speaker": "JME"
     },
     {
-      "id": 958,
+      "id": 960,
       "start": 1342.17,
-      "end": 1342.53,
-      "text": "Char,",
+      "end": 1343.73,
+      "text": "Char, ay, can I go in now?",
       "words": [
         {
           "word": "Char,",
           "start": 1342.17,
           "end": 1342.53,
           "probability": 0.22024236619472504
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 959,
-      "start": 1342.71,
-      "end": 1342.91,
-      "text": "ay,",
-      "words": [
+        },
         {
           "word": "ay,",
           "start": 1342.71,
           "end": 1342.91,
           "probability": 0.14313523471355438
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 960,
-      "start": 1343.03,
-      "end": 1343.73,
-      "text": "can I go in now?",
-      "words": [
+        },
         {
           "word": "can",
           "start": 1343.03,
@@ -38383,8 +37069,8 @@
     {
       "id": 961,
       "start": 1345.47,
-      "end": 1346.89,
-      "text": "Canary Wharf and the Gherkin",
+      "end": 1347.25,
+      "text": "Canary Wharf and the Gherkin Ay,",
       "words": [
         {
           "word": "Canary",
@@ -38415,16 +37101,7 @@
           "start": 1346.45,
           "end": 1346.89,
           "probability": 0.8217163483301798
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 962,
-      "start": 1346.89,
-      "end": 1347.25,
-      "text": "Ay,",
-      "words": [
+        },
         {
           "word": "Ay,",
           "start": 1346.89,
@@ -38578,8 +37255,8 @@
     {
       "id": 966,
       "start": 1352.37,
-      "end": 1353.53,
-      "text": "That my chest is hurting",
+      "end": 1354.01,
+      "text": "That my chest is hurting See,",
       "words": [
         {
           "word": "That",
@@ -38610,16 +37287,7 @@
           "start": 1353.21,
           "end": 1353.53,
           "probability": 0.982731282711029
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 967,
-      "start": 1353.53,
-      "end": 1354.01,
-      "text": "See,",
-      "words": [
+        },
         {
           "word": "See,",
           "start": 1353.53,
@@ -38807,41 +37475,23 @@
       "speaker": "Skepta"
     },
     {
-      "id": 971,
+      "id": 973,
       "start": 1359.95,
-      "end": 1360.57,
-      "text": "calls",
+      "end": 1362.55,
+      "text": "calls Chris, no less than section 18",
       "words": [
         {
           "word": "calls",
           "start": 1359.95,
           "end": 1360.57,
           "probability": 0.9943304061889648
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 972,
-      "start": 1360.57,
-      "end": 1361.21,
-      "text": "Chris,",
-      "words": [
+        },
         {
           "word": "Chris,",
           "start": 1360.57,
           "end": 1361.21,
           "probability": 0.4443376958370209
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 973,
-      "start": 1361.45,
-      "end": 1362.55,
-      "text": "no less than section 18",
-      "words": [
+        },
         {
           "word": "no",
           "start": 1361.45,
@@ -38878,8 +37528,8 @@
     {
       "id": 974,
       "start": 1362.55,
-      "end": 1363.57,
-      "text": "When I catch them fools",
+      "end": 1363.97,
+      "text": "When I catch them fools Ay,",
       "words": [
         {
           "word": "When",
@@ -38910,16 +37560,7 @@
           "start": 1363.25,
           "end": 1363.57,
           "probability": 0.9922296404838562
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 975,
-      "start": 1363.57,
-      "end": 1363.97,
-      "text": "Ay,",
-      "words": [
+        },
         {
           "word": "Ay,",
           "start": 1363.57,
@@ -38989,8 +37630,8 @@
     {
       "id": 977,
       "start": 1365.33,
-      "end": 1367.01,
-      "text": "Cause that pussy ain't got no balls",
+      "end": 1367.43,
+      "text": "Cause that pussy ain't got no balls Ay,",
       "words": [
         {
           "word": "Cause",
@@ -39033,16 +37674,7 @@
           "start": 1366.71,
           "end": 1367.01,
           "probability": 0.988878071308136
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 978,
-      "start": 1367.01,
-      "end": 1367.43,
-      "text": "Ay,",
-      "words": [
+        },
         {
           "word": "Ay,",
           "start": 1367.01,
@@ -39316,8 +37948,8 @@
     {
       "id": 984,
       "start": 1375.73,
-      "end": 1376.47,
-      "text": "A drink filled man,",
+      "end": 1377.21,
+      "text": "A drink filled man, a Ravina",
       "words": [
         {
           "word": "A",
@@ -39342,16 +37974,7 @@
           "start": 1376.29,
           "end": 1376.47,
           "probability": 0.7550411820411682
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 985,
-      "start": 1376.51,
-      "end": 1377.21,
-      "text": "a Ravina",
-      "words": [
+        },
         {
           "word": "a",
           "start": 1376.51,
@@ -39427,8 +38050,8 @@
     {
       "id": 987,
       "start": 1379.05,
-      "end": 1380.49,
-      "text": "Maradona or Argentina",
+      "end": 1380.97,
+      "text": "Maradona or Argentina See,",
       "words": [
         {
           "word": "Maradona",
@@ -39447,16 +38070,7 @@
           "start": 1379.71,
           "end": 1380.49,
           "probability": 0.9883155822753906
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 988,
-      "start": 1380.49,
-      "end": 1380.97,
-      "text": "See,",
-      "words": [
+        },
         {
           "word": "See,",
           "start": 1380.49,
@@ -39530,10 +38144,10 @@
       "speaker": "Skepta"
     },
     {
-      "id": 990,
+      "id": 991,
       "start": 1382.37,
-      "end": 1382.61,
-      "text": "the dark",
+      "end": 1383.87,
+      "text": "the dark From my hot jungle fever",
       "words": [
         {
           "word": "the",
@@ -39546,16 +38160,7 @@
           "start": 1382.49,
           "end": 1382.61,
           "probability": 0.9838758111000061
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 991,
-      "start": 1382.61,
-      "end": 1383.87,
-      "text": "From my hot jungle fever",
-      "words": [
+        },
         {
           "word": "From",
           "start": 1382.61,
@@ -39814,8 +38419,8 @@
     {
       "id": 996,
       "start": 1390.01,
-      "end": 1391.27,
-      "text": "If it's this J and me then it costs",
+      "end": 1391.13,
+      "text": "If it's this J and me then it",
       "words": [
         {
           "word": "If",
@@ -39864,22 +38469,22 @@
           "start": 1390.97,
           "end": 1391.13,
           "probability": 0.7976886630058289
-        },
-        {
-          "word": "costs",
-          "start": 1391.13,
-          "end": 1391.27,
-          "probability": 0.3440302908420563
         }
       ],
       "speaker": "Skepta"
     },
     {
       "id": 997,
-      "start": 1391.27,
+      "start": 1391.13,
       "end": 1391.77,
-      "text": "my line",
+      "text": "costs my line",
       "words": [
+        {
+          "word": "costs",
+          "start": 1391.13,
+          "end": 1391.27,
+          "probability": 0.3440302908420563
+        },
         {
           "word": "my",
           "start": 1391.27,
@@ -40069,8 +38674,8 @@
     {
       "id": 1001,
       "start": 1396.81,
-      "end": 1398.07,
-      "text": "If it's this J and me then it costs",
+      "end": 1397.93,
+      "text": "If it's this J and me then it",
       "words": [
         {
           "word": "If",
@@ -40119,22 +38724,22 @@
           "start": 1397.79,
           "end": 1397.93,
           "probability": 0.9717402458190918
-        },
-        {
-          "word": "costs",
-          "start": 1397.93,
-          "end": 1398.07,
-          "probability": 0.4104987382888794
         }
       ],
       "speaker": "Skepta"
     },
     {
       "id": 1002,
-      "start": 1398.07,
+      "start": 1397.93,
       "end": 1398.73,
-      "text": "my line",
+      "text": "costs my line",
       "words": [
+        {
+          "word": "costs",
+          "start": 1397.93,
+          "end": 1398.07,
+          "probability": 0.4104987382888794
+        },
         {
           "word": "my",
           "start": 1398.07,
@@ -40252,8 +38857,8 @@
     {
       "id": 1006,
       "start": 1403.83,
-      "end": 1405.79,
-      "text": "Hand on the Bible spit like a Pella",
+      "end": 1406.45,
+      "text": "Hand on the Bible spit like a Pella Listeners,",
       "words": [
         {
           "word": "Hand",
@@ -40302,16 +38907,7 @@
           "start": 1405.21,
           "end": 1405.79,
           "probability": 0.5627827942371368
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1007,
-      "start": 1405.79,
-      "end": 1406.45,
-      "text": "Listeners,",
-      "words": [
+        },
         {
           "word": "Listeners,",
           "start": 1405.79,
@@ -40424,10 +39020,10 @@
       "speaker": "JME"
     },
     {
-      "id": 1010,
+      "id": 1011,
       "start": 1409.63,
-      "end": 1410.53,
-      "text": "Like Salmanilla",
+      "end": 1412.21,
+      "text": "Like Salmanilla Get beatboxed like Jilop Keller",
       "words": [
         {
           "word": "Like",
@@ -40440,16 +39036,7 @@
           "start": 1409.89,
           "end": 1410.53,
           "probability": 0.5735305150349935
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1011,
-      "start": 1410.53,
-      "end": 1412.21,
-      "text": "Get beatboxed like Jilop Keller",
-      "words": [
+        },
         {
           "word": "Get",
           "start": 1410.53,
@@ -40486,8 +39073,8 @@
     {
       "id": 1012,
       "start": 1412.21,
-      "end": 1414.09,
-      "text": "Puff Man Ting with a stella",
+      "end": 1414.81,
+      "text": "Puff Man Ting with a stella Left hook,",
       "words": [
         {
           "word": "Puff",
@@ -40524,16 +39111,7 @@
           "start": 1413.71,
           "end": 1414.09,
           "probability": 0.5600824803113937
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1013,
-      "start": 1414.09,
-      "end": 1414.81,
-      "text": "Left hook,",
-      "words": [
+        },
         {
           "word": "Left",
           "start": 1414.09,
@@ -40550,10 +39128,10 @@
       "speaker": "JME"
     },
     {
-      "id": 1014,
+      "id": 1015,
       "start": 1415.01,
-      "end": 1415.27,
-      "text": "top lip,",
+      "end": 1417.31,
+      "text": "top lip, swell up Wobbly tooth, fairvon Jella",
       "words": [
         {
           "word": "top",
@@ -40566,16 +39144,7 @@
           "start": 1415.13,
           "end": 1415.27,
           "probability": 0.37399429082870483
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1015,
-      "start": 1415.31,
-      "end": 1415.73,
-      "text": "swell up",
-      "words": [
+        },
         {
           "word": "swell",
           "start": 1415.31,
@@ -40587,16 +39156,7 @@
           "start": 1415.51,
           "end": 1415.73,
           "probability": 0.23632994294166565
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1016,
-      "start": 1415.73,
-      "end": 1416.51,
-      "text": "Wobbly tooth,",
-      "words": [
+        },
         {
           "word": "Wobbly",
           "start": 1415.73,
@@ -40608,16 +39168,7 @@
           "start": 1416.15,
           "end": 1416.51,
           "probability": 0.5749741792678833
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1017,
-      "start": 1416.75,
-      "end": 1417.31,
-      "text": "fairvon Jella",
-      "words": [
+        },
         {
           "word": "fairvon",
           "start": 1416.75,
@@ -40846,8 +39397,8 @@
     {
       "id": 1022,
       "start": 1424.43,
-      "end": 1425.37,
-      "text": "You don't believe me?",
+      "end": 1426.11,
+      "text": "You don't believe me? Ask Mella",
       "words": [
         {
           "word": "You",
@@ -40872,16 +39423,7 @@
           "start": 1425.09,
           "end": 1425.37,
           "probability": 0.9934095144271851
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1023,
-      "start": 1425.37,
-      "end": 1426.11,
-      "text": "Ask Mella",
-      "words": [
+        },
         {
           "word": "Ask",
           "start": 1425.37,
@@ -41188,8 +39730,8 @@
     {
       "id": 1032,
       "start": 1436.07,
-      "end": 1437.93,
-      "text": "You get a Texas chainsaw massacre",
+      "end": 1439.17,
+      "text": "You get a Texas chainsaw massacre Modern warfare, silence,",
       "words": [
         {
           "word": "You",
@@ -41226,16 +39768,7 @@
           "start": 1437.39,
           "end": 1437.93,
           "probability": 0.9680748581886292
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1033,
-      "start": 1437.93,
-      "end": 1438.63,
-      "text": "Modern warfare,",
-      "words": [
+        },
         {
           "word": "Modern",
           "start": 1437.93,
@@ -41247,16 +39780,7 @@
           "start": 1438.31,
           "end": 1438.63,
           "probability": 0.8923967480659485
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1034,
-      "start": 1438.73,
-      "end": 1439.17,
-      "text": "silence,",
-      "words": [
+        },
         {
           "word": "silence,",
           "start": 1438.73,
@@ -41267,10 +39791,10 @@
       "speaker": "JME"
     },
     {
-      "id": 1035,
+      "id": 1036,
       "start": 1439.95,
-      "end": 1440.21,
-      "text": "no chaps,",
+      "end": 1441.23,
+      "text": "no chaps, no chain, no manager",
       "words": [
         {
           "word": "no",
@@ -41283,16 +39807,7 @@
           "start": 1439.95,
           "end": 1440.21,
           "probability": 0.7809481024742126
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1036,
-      "start": 1440.33,
-      "end": 1440.63,
-      "text": "no chain,",
-      "words": [
+        },
         {
           "word": "no",
           "start": 1440.33,
@@ -41304,16 +39819,7 @@
           "start": 1440.47,
           "end": 1440.63,
           "probability": 0.9285630583763123
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1037,
-      "start": 1440.65,
-      "end": 1441.23,
-      "text": "no manager",
-      "words": [
+        },
         {
           "word": "no",
           "start": 1440.65,
@@ -41444,26 +39950,17 @@
       "speaker": "JME"
     },
     {
-      "id": 1040,
+      "id": 1041,
       "start": 1445.05,
-      "end": 1445.25,
-      "text": "them",
+      "end": 1447.15,
+      "text": "them With a lens and an aperture, professional",
       "words": [
         {
           "word": "them",
           "start": 1445.05,
           "end": 1445.25,
           "probability": 0.9769630432128906
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1041,
-      "start": 1445.25,
-      "end": 1446.45,
-      "text": "With a lens and an aperture,",
-      "words": [
+        },
         {
           "word": "With",
           "start": 1445.25,
@@ -41499,16 +39996,7 @@
           "start": 1446.05,
           "end": 1446.45,
           "probability": 0.9903355836868286
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1042,
-      "start": 1446.81,
-      "end": 1447.15,
-      "text": "professional",
-      "words": [
+        },
         {
           "word": "professional",
           "start": 1446.81,
@@ -41519,10 +40007,10 @@
       "speaker": "JME"
     },
     {
-      "id": 1043,
+      "id": 1044,
       "start": 1447.15,
-      "end": 1448.05,
-      "text": "Not amateur,",
+      "end": 1449.91,
+      "text": "Not amateur, cause I work all night like Dracula",
       "words": [
         {
           "word": "Not",
@@ -41535,16 +40023,7 @@
           "start": 1447.59,
           "end": 1448.05,
           "probability": 0.9852105975151062
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1044,
-      "start": 1448.31,
-      "end": 1449.91,
-      "text": "cause I work all night like Dracula",
-      "words": [
+        },
         {
           "word": "cause",
           "start": 1448.31,
@@ -41699,26 +40178,17 @@
       "speaker": "JME"
     },
     {
-      "id": 1047,
+      "id": 1048,
       "start": 1453.77,
-      "end": 1454.05,
-      "text": "Yo,",
+      "end": 1455.37,
+      "text": "Yo, I ain't taking you nowhere",
       "words": [
         {
           "word": "Yo,",
           "start": 1453.77,
           "end": 1454.05,
           "probability": 0.8355693817138672
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 1048,
-      "start": 1454.19,
-      "end": 1455.37,
-      "text": "I ain't taking you nowhere",
-      "words": [
+        },
         {
           "word": "I",
           "start": 1454.19,
@@ -42110,41 +40580,23 @@
       "speaker": "Frisco"
     },
     {
-      "id": 1056,
+      "id": 1058,
       "start": 1465.63,
-      "end": 1465.89,
-      "text": "doctor",
+      "end": 1466.55,
+      "text": "doctor Remember, boy,",
       "words": [
         {
           "word": "doctor",
           "start": 1465.63,
           "end": 1465.89,
           "probability": 0.499493807554245
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 1057,
-      "start": 1465.89,
-      "end": 1466.31,
-      "text": "Remember,",
-      "words": [
+        },
         {
           "word": "Remember,",
           "start": 1465.89,
           "end": 1466.31,
           "probability": 0.17501908540725708
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 1058,
-      "start": 1466.49,
-      "end": 1466.55,
-      "text": "boy,",
-      "words": [
+        },
         {
           "word": "boy,",
           "start": 1466.49,
@@ -43069,8 +41521,8 @@
     {
       "id": 1081,
       "start": 1492.67,
-      "end": 1494.07,
-      "text": "this me a thump in the mouth",
+      "end": 1494.47,
+      "text": "this me a thump in the mouth Shout,",
       "words": [
         {
           "word": "this",
@@ -43113,16 +41565,7 @@
           "start": 1493.73,
           "end": 1494.07,
           "probability": 0.9954220652580261
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 1082,
-      "start": 1494.07,
-      "end": 1494.47,
-      "text": "Shout,",
-      "words": [
+        },
         {
           "word": "Shout,",
           "start": 1494.07,
@@ -43327,8 +41770,8 @@
     {
       "id": 1087,
       "start": 1499.81,
-      "end": 1501.01,
-      "text": "my throat starts hurting",
+      "end": 1501.33,
+      "text": "my throat starts hurting Fam,",
       "words": [
         {
           "word": "my",
@@ -43353,16 +41796,7 @@
           "start": 1500.47,
           "end": 1501.01,
           "probability": 0.9889950752258301
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 1088,
-      "start": 1501.01,
-      "end": 1501.33,
-      "text": "Fam,",
-      "words": [
+        },
         {
           "word": "Fam,",
           "start": 1501.01,
@@ -43475,10 +41909,10 @@
       "speaker": "Frisco"
     },
     {
-      "id": 1091,
+      "id": 1092,
       "start": 1503.77,
-      "end": 1504.07,
-      "text": "the eye",
+      "end": 1505.91,
+      "text": "the eye I'm a cussed up alive, always recording",
       "words": [
         {
           "word": "the",
@@ -43491,16 +41925,7 @@
           "start": 1503.95,
           "end": 1504.07,
           "probability": 0.9245985746383667
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 1092,
-      "start": 1504.07,
-      "end": 1505.01,
-      "text": "I'm a cussed up alive,",
-      "words": [
+        },
         {
           "word": "I'm",
           "start": 1504.07,
@@ -43530,16 +41955,7 @@
           "start": 1504.71,
           "end": 1505.01,
           "probability": 0.4453534483909607
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 1093,
-      "start": 1505.17,
-      "end": 1505.91,
-      "text": "always recording",
-      "words": [
+        },
         {
           "word": "always",
           "start": 1505.17,
@@ -43556,26 +41972,17 @@
       "speaker": "Frisco"
     },
     {
-      "id": 1094,
+      "id": 1095,
       "start": 1505.91,
-      "end": 1506.17,
-      "text": "Boy,",
+      "end": 1507.97,
+      "text": "Boy, but I know we're ripping it right",
       "words": [
         {
           "word": "Boy,",
           "start": 1505.91,
           "end": 1506.17,
           "probability": 0.26905950903892517
-        }
-      ],
-      "speaker": "Frisco"
-    },
-    {
-      "id": 1095,
-      "start": 1506.21,
-      "end": 1507.97,
-      "text": "but I know we're ripping it right",
-      "words": [
+        },
         {
           "word": "but",
           "start": 1506.21,
@@ -43681,8 +42088,8 @@
     {
       "id": 1097,
       "start": 1509.71,
-      "end": 1510.41,
-      "text": "Buy out the bar,",
+      "end": 1510.95,
+      "text": "Buy out the bar, that's me",
       "words": [
         {
           "word": "Buy",
@@ -43707,16 +42114,7 @@
           "start": 1510.29,
           "end": 1510.41,
           "probability": 0.8075066804885864
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 1098,
-      "start": 1510.41,
-      "end": 1510.95,
-      "text": "that's me",
-      "words": [
+        },
         {
           "word": "that's",
           "start": 1510.41,
@@ -43780,8 +42178,8 @@
     {
       "id": 1100,
       "start": 1512.65,
-      "end": 1514.29,
-      "text": "Ten green bottles on the roof of the team",
+      "end": 1513.95,
+      "text": "Ten green bottles on the roof of",
       "words": [
         {
           "word": "Ten",
@@ -43824,7 +42222,16 @@
           "start": 1513.77,
           "end": 1513.95,
           "probability": 0.6200860142707825
-        },
+        }
+      ],
+      "speaker": "Jammer"
+    },
+    {
+      "id": 1101,
+      "start": 1513.95,
+      "end": 1514.63,
+      "text": "the team Boy,",
+      "words": [
         {
           "word": "the",
           "start": 1513.95,
@@ -43836,16 +42243,7 @@
           "start": 1514.11,
           "end": 1514.29,
           "probability": 0.8244529962539673
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 1101,
-      "start": 1514.29,
-      "end": 1514.63,
-      "text": "Boy,",
-      "words": [
+        },
         {
           "word": "Boy,",
           "start": 1514.29,
@@ -44135,10 +42533,10 @@
       "speaker": "Jammer"
     },
     {
-      "id": 1107,
+      "id": 1108,
       "start": 1522.89,
-      "end": 1523.35,
-      "text": "a P",
+      "end": 1524.59,
+      "text": "a P Buy out the bar, that's me",
       "words": [
         {
           "word": "a",
@@ -44151,16 +42549,7 @@
           "start": 1523.05,
           "end": 1523.35,
           "probability": 0.9908697009086609
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 1108,
-      "start": 1523.35,
-      "end": 1524.01,
-      "text": "Buy out the bar,",
-      "words": [
+        },
         {
           "word": "Buy",
           "start": 1523.35,
@@ -44184,16 +42573,7 @@
           "start": 1523.81,
           "end": 1524.01,
           "probability": 0.9986206293106079
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 1109,
-      "start": 1524.01,
-      "end": 1524.59,
-      "text": "that's me",
-      "words": [
+        },
         {
           "word": "that's",
           "start": 1524.01,
@@ -44257,8 +42637,8 @@
     {
       "id": 1111,
       "start": 1526.25,
-      "end": 1527.95,
-      "text": "Ten green bottles on the roof of the team",
+      "end": 1527.53,
+      "text": "Ten green bottles on the roof of",
       "words": [
         {
           "word": "Ten",
@@ -44301,7 +42681,16 @@
           "start": 1527.43,
           "end": 1527.53,
           "probability": 0.9982092380523682
-        },
+        }
+      ],
+      "speaker": "Jammer"
+    },
+    {
+      "id": 1112,
+      "start": 1527.53,
+      "end": 1528.15,
+      "text": "the team Boy,",
+      "words": [
         {
           "word": "the",
           "start": 1527.53,
@@ -44313,16 +42702,7 @@
           "start": 1527.71,
           "end": 1527.95,
           "probability": 0.9988376498222351
-        }
-      ],
-      "speaker": "Jammer"
-    },
-    {
-      "id": 1112,
-      "start": 1527.95,
-      "end": 1528.15,
-      "text": "Boy,",
-      "words": [
+        },
         {
           "word": "Boy,",
           "start": 1527.95,
@@ -44518,8 +42898,8 @@
     {
       "id": 1116,
       "start": 1533.09,
-      "end": 1533.95,
-      "text": "Aim for the target",
+      "end": 1534.67,
+      "text": "Aim for the target Well,",
       "words": [
         {
           "word": "Aim",
@@ -44544,16 +42924,7 @@
           "start": 1533.63,
           "end": 1533.95,
           "probability": 0.9612709879875183
-        }
-      ],
-      "speaker": "unknown"
-    },
-    {
-      "id": 1117,
-      "start": 1533.95,
-      "end": 1534.67,
-      "text": "Well,",
-      "words": [
+        },
         {
           "word": "Well,",
           "start": 1533.95,
@@ -44564,26 +42935,17 @@
       "speaker": "unknown"
     },
     {
-      "id": 1118,
+      "id": 1119,
       "start": 1535.25,
-      "end": 1535.53,
-      "text": "well,",
+      "end": 1536.07,
+      "text": "well, well",
       "words": [
         {
           "word": "well,",
           "start": 1535.25,
           "end": 1535.53,
           "probability": 0.9556661248207092
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1119,
-      "start": 1535.53,
-      "end": 1536.07,
-      "text": "well",
-      "words": [
+        },
         {
           "word": "well",
           "start": 1535.53,
@@ -44893,8 +43255,8 @@
     {
       "id": 1125,
       "start": 1545.31,
-      "end": 1547.07,
-      "text": "And you'll get an elbow drop like well,",
+      "end": 1547.45,
+      "text": "And you'll get an elbow drop like well, well,",
       "words": [
         {
           "word": "And",
@@ -44943,16 +43305,7 @@
           "start": 1546.81,
           "end": 1547.07,
           "probability": 0.3678392469882965
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1126,
-      "start": 1547.17,
-      "end": 1547.45,
-      "text": "well,",
-      "words": [
+        },
         {
           "word": "well,",
           "start": 1547.17,
@@ -44963,56 +43316,29 @@
       "speaker": "JME"
     },
     {
-      "id": 1127,
+      "id": 1129,
       "start": 1547.53,
-      "end": 1547.83,
-      "text": "well",
+      "end": 1548.83,
+      "text": "well Well, well, well,",
       "words": [
         {
           "word": "well",
           "start": 1547.53,
           "end": 1547.83,
           "probability": 0.9964610934257507
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1128,
-      "start": 1547.83,
-      "end": 1547.95,
-      "text": "Well,",
-      "words": [
+        },
         {
           "word": "Well,",
           "start": 1547.83,
           "end": 1547.95,
           "probability": 0.05892154946923256
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1129,
-      "start": 1547.95,
-      "end": 1548.27,
-      "text": "well,",
-      "words": [
+        },
         {
           "word": "well,",
           "start": 1547.95,
           "end": 1548.27,
           "probability": 0.994499921798706
-        }
-      ],
-      "speaker": "JME"
-    },
-    {
-      "id": 1130,
-      "start": 1548.27,
-      "end": 1548.83,
-      "text": "well,",
-      "words": [
+        },
         {
           "word": "well,",
           "start": 1548.27,
@@ -45023,41 +43349,23 @@
       "speaker": "JME"
     },
     {
-      "id": 1131,
+      "id": 1133,
       "start": 1548.83,
-      "end": 1549.11,
-      "text": "well",
+      "end": 1551.35,
+      "text": "well Hey, what did I get?",
       "words": [
         {
           "word": "well",
           "start": 1548.83,
           "end": 1549.11,
           "probability": 0.9856248497962952
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 1132,
-      "start": 1549.53,
-      "end": 1549.93,
-      "text": "Hey,",
-      "words": [
+        },
         {
           "word": "Hey,",
           "start": 1549.53,
           "end": 1549.93,
           "probability": 0.08908619731664658
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 1133,
-      "start": 1550.11,
-      "end": 1551.35,
-      "text": "what did I get?",
-      "words": [
+        },
         {
           "word": "what",
           "start": 1550.11,
@@ -45088,8 +43396,8 @@
     {
       "id": 1134,
       "start": 1552.55,
-      "end": 1553.19,
-      "text": "In the paper,",
+      "end": 1554.41,
+      "text": "In the paper, one, two, one, two",
       "words": [
         {
           "word": "In",
@@ -45108,61 +43416,25 @@
           "start": 1552.81,
           "end": 1553.19,
           "probability": 0.9813486933708191
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 1135,
-      "start": 1553.41,
-      "end": 1553.63,
-      "text": "one,",
-      "words": [
+        },
         {
           "word": "one,",
           "start": 1553.41,
           "end": 1553.63,
           "probability": 0.7018841505050659
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 1136,
-      "start": 1553.65,
-      "end": 1553.77,
-      "text": "two,",
-      "words": [
+        },
         {
           "word": "two,",
           "start": 1553.65,
           "end": 1553.77,
           "probability": 0.9972121119499207
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 1137,
-      "start": 1554.03,
-      "end": 1554.03,
-      "text": "one,",
-      "words": [
+        },
         {
           "word": "one,",
           "start": 1554.03,
           "end": 1554.03,
           "probability": 0.09845556318759918
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 1138,
-      "start": 1554.15,
-      "end": 1554.41,
-      "text": "two",
-      "words": [
+        },
         {
           "word": "two",
           "start": 1554.15,
@@ -45514,8 +43786,8 @@
     {
       "id": 1146,
       "start": 1564.95,
-      "end": 1566.35,
-      "text": "I feel so alive and I couldn't give a",
+      "end": 1566.27,
+      "text": "I feel so alive and I couldn't give",
       "words": [
         {
           "word": "I",
@@ -45564,22 +43836,22 @@
           "start": 1566.07,
           "end": 1566.27,
           "probability": 0.9763203859329224
-        },
-        {
-          "word": "a",
-          "start": 1566.27,
-          "end": 1566.35,
-          "probability": 0.9923871755599976
         }
       ],
       "speaker": "Skepta"
     },
     {
       "id": 1147,
-      "start": 1566.35,
+      "start": 1566.27,
       "end": 1566.71,
-      "text": "damn about",
+      "text": "a damn about",
       "words": [
+        {
+          "word": "a",
+          "start": 1566.27,
+          "end": 1566.35,
+          "probability": 0.9923871755599976
+        },
         {
           "word": "damn",
           "start": 1566.35,
@@ -45766,8 +44038,8 @@
     {
       "id": 1152,
       "start": 1571.85,
-      "end": 1572.91,
-      "text": "When you're looking for Boy,",
+      "end": 1573.33,
+      "text": "When you're looking for Boy, better know,",
       "words": [
         {
           "word": "When",
@@ -45798,16 +44070,7 @@
           "start": 1572.79,
           "end": 1572.91,
           "probability": 0.29021716117858887
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 1153,
-      "start": 1572.99,
-      "end": 1573.33,
-      "text": "better know,",
-      "words": [
+        },
         {
           "word": "better",
           "start": 1572.99,
@@ -45826,8 +44089,8 @@
     {
       "id": 1154,
       "start": 1573.45,
-      "end": 1574.61,
-      "text": "better look to the stars",
+      "end": 1575.45,
+      "text": "better look to the stars Boy, better know,",
       "words": [
         {
           "word": "better",
@@ -45858,31 +44121,13 @@
           "start": 1574.19,
           "end": 1574.61,
           "probability": 0.9892675280570984
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 1155,
-      "start": 1574.61,
-      "end": 1575.13,
-      "text": "Boy,",
-      "words": [
+        },
         {
           "word": "Boy,",
           "start": 1574.61,
           "end": 1575.13,
           "probability": 0.8193100094795227
-        }
-      ],
-      "speaker": "Skepta"
-    },
-    {
-      "id": 1156,
-      "start": 1575.15,
-      "end": 1575.45,
-      "text": "better know,",
-      "words": [
+        },
         {
           "word": "better",
           "start": 1575.15,
@@ -45899,10 +44144,10 @@
       "speaker": "Skepta"
     },
     {
-      "id": 1157,
+      "id": 1158,
       "start": 1575.61,
-      "end": 1576.13,
-      "text": "Kiss Presents",
+      "end": 1577.51,
+      "text": "Kiss Presents Kicking off the Grime Takeover,",
       "words": [
         {
           "word": "Kiss",
@@ -45915,16 +44160,7 @@
           "start": 1575.75,
           "end": 1576.13,
           "probability": 0.5176628232002258
-        }
-      ],
-      "speaker": "Logan Sama"
-    },
-    {
-      "id": 1158,
-      "start": 1576.13,
-      "end": 1577.51,
-      "text": "Kicking off the Grime Takeover,",
-      "words": [
+        },
         {
           "word": "Kicking",
           "start": 1576.13,

--- a/data/ARCHIVE_007_data.json
+++ b/data/ARCHIVE_007_data.json
@@ -1,6 +1,6 @@
 {
   "title": "Logan Sama vs BBK crew 2007",
-  "duration": 538.00,
+  "duration": 538.0,
   "instrumentals": [
     {
       "start": 0.0,
@@ -63,7 +63,7 @@
       "id": 9,
       "start": 0.26,
       "end": 1.72,
-      "text": "Alright it’s the next hype yeah?",
+      "text": "Alright it\u2019s the next hype yeah?",
       "words": [
         {
           "start": 0.26,
@@ -73,7 +73,7 @@
         {
           "start": 0.7,
           "end": 1.04,
-          "word": " it’s"
+          "word": " it\u2019s"
         },
         {
           "start": 1.04,
@@ -100,30 +100,20 @@
       "instrumental": null
     },
     {
-      "id": 10,
+      "id": 11,
       "start": 1.78,
-      "end": 2.08,
-      "text": "Yes",
+      "end": 3.12,
+      "text": "Yes We\u2019ve been waiting,",
       "words": [
         {
           "start": 1.78,
           "end": 2.08,
           "word": " Yes"
-        }
-      ],
-      "speaker": "Logan Sama",
-      "instrumental": null
-    },
-    {
-      "id": 11,
-      "start": 2.08,
-      "end": 3.12,
-      "text": "We’ve been waiting,",
-      "words": [
+        },
         {
           "start": 2.08,
           "end": 2.84,
-          "word": " We’ve"
+          "word": " We\u2019ve"
         },
         {
           "start": 2.84,
@@ -143,12 +133,12 @@
       "id": 12,
       "start": 3.38,
       "end": 3.88,
-      "text": "we’ve been waiting",
+      "text": "we\u2019ve been waiting",
       "words": [
         {
           "start": 3.38,
           "end": 3.64,
-          "word": " we’ve"
+          "word": " we\u2019ve"
         },
         {
           "start": 3.64,
@@ -165,41 +155,21 @@
       "instrumental": null
     },
     {
-      "id": 13,
+      "id": 15,
       "start": 3.88,
-      "end": 4.28,
-      "text": "Yo,",
+      "end": 4.74,
+      "text": "Yo, yo, yo",
       "words": [
         {
           "start": 3.88,
           "end": 4.28,
           "word": " Yo,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 14,
-      "start": 4.3,
-      "end": 4.36,
-      "text": "yo,",
-      "words": [
+        },
         {
           "start": 4.3,
           "end": 4.36,
           "word": " yo,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 15,
-      "start": 4.44,
-      "end": 4.74,
-      "text": "yo",
-      "words": [
+        },
         {
           "start": 4.44,
           "end": 4.74,
@@ -327,13 +297,13 @@
     {
       "id": 19,
       "start": 8.26,
-      "end": 9.7,
-      "text": "I’ll come for the beans that you",
+      "end": 9.92,
+      "text": "I\u2019ll come for the beans that you stack",
       "words": [
         {
           "start": 8.26,
           "end": 8.8,
-          "word": " I’ll"
+          "word": " I\u2019ll"
         },
         {
           "start": 8.8,
@@ -364,17 +334,7 @@
           "start": 9.6,
           "end": 9.7,
           "word": " you"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 20,
-      "start": 9.7,
-      "end": 9.92,
-      "text": "stack",
-      "words": [
+        },
         {
           "start": 9.7,
           "end": 9.92,
@@ -387,8 +347,8 @@
     {
       "id": 21,
       "start": 9.92,
-      "end": 11.32,
-      "text": "And come for all the food that",
+      "end": 11.62,
+      "text": "And come for all the food that you block",
       "words": [
         {
           "start": 9.92,
@@ -424,17 +384,7 @@
           "start": 11.18,
           "end": 11.32,
           "word": " that"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 22,
-      "start": 11.32,
-      "end": 11.62,
-      "text": "you block",
-      "words": [
+        },
         {
           "start": 11.32,
           "end": 11.4,
@@ -488,7 +438,7 @@
       "id": 24,
       "start": 13.34,
       "end": 15.0,
-      "text": "Your buddies don’t wanna see you shot",
+      "text": "Your buddies don\u2019t wanna see you shot",
       "words": [
         {
           "start": 13.34,
@@ -503,7 +453,7 @@
         {
           "start": 13.94,
           "end": 14.16,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 14.16,
@@ -532,8 +482,8 @@
     {
       "id": 25,
       "start": 15.0,
-      "end": 16.36,
-      "text": "If I kick down the door to",
+      "end": 16.68,
+      "text": "If I kick down the door to your flat",
       "words": [
         {
           "start": 15.0,
@@ -569,17 +519,7 @@
           "start": 16.22,
           "end": 16.36,
           "word": " to"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 26,
-      "start": 16.36,
-      "end": 16.68,
-      "text": "your flat",
-      "words": [
+        },
         {
           "start": 16.36,
           "end": 16.46,
@@ -657,8 +597,8 @@
     {
       "id": 29,
       "start": 18.36,
-      "end": 20.14,
-      "text": "Clear all the things in the house,",
+      "end": 20.42,
+      "text": "Clear all the things in the house, Clear !",
       "words": [
         {
           "start": 18.36,
@@ -694,17 +634,7 @@
           "start": 19.86,
           "end": 20.14,
           "word": " house,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 30,
-      "start": 20.18,
-      "end": 20.42,
-      "text": "Clear !",
-      "words": [
+        },
         {
           "start": 20.18,
           "end": 20.42,
@@ -717,8 +647,8 @@
     {
       "id": 31,
       "start": 20.42,
-      "end": 21.78,
-      "text": "All the things in the fridge,",
+      "end": 22.1,
+      "text": "All the things in the fridge, Smash !",
       "words": [
         {
           "start": 20.42,
@@ -749,17 +679,7 @@
           "start": 21.56,
           "end": 21.78,
           "word": " fridge,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 32,
-      "start": 21.92,
-      "end": 22.1,
-      "text": "Smash !",
-      "words": [
+        },
         {
           "start": 21.92,
           "end": 22.1,
@@ -772,8 +692,8 @@
     {
       "id": 33,
       "start": 22.48,
-      "end": 23.42,
-      "text": "All your blinks on the rack,",
+      "end": 23.84,
+      "text": "All your blinks on the rack, Clear !",
       "words": [
         {
           "start": 22.48,
@@ -804,17 +724,7 @@
           "start": 23.26,
           "end": 23.42,
           "word": " rack,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 34,
-      "start": 23.5,
-      "end": 23.84,
-      "text": "Clear !",
-      "words": [
+        },
         {
           "start": 23.5,
           "end": 23.84,
@@ -827,8 +737,8 @@
     {
       "id": 35,
       "start": 23.84,
-      "end": 24.66,
-      "text": "All your food,",
+      "end": 25.52,
+      "text": "All your food, these toys,  Clear !",
       "words": [
         {
           "start": 23.84,
@@ -844,17 +754,7 @@
           "start": 24.44,
           "end": 24.66,
           "word": " food,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 36,
-      "start": 24.68,
-      "end": 25.1,
-      "text": "these toys,",
-      "words": [
+        },
         {
           "start": 24.68,
           "end": 24.82,
@@ -864,17 +764,7 @@
           "start": 24.82,
           "end": 25.1,
           "word": " toys,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 37,
-      "start": 25.26,
-      "end": 25.52,
-      "text": " Clear !",
-      "words": [
+        },
         {
           "start": 25.26,
           "end": 25.52,
@@ -918,12 +808,12 @@
       "id": 39,
       "start": 26.9,
       "end": 28.54,
-      "text": "won’t get none of your CDs back",
+      "text": "won\u2019t get none of your CDs back",
       "words": [
         {
           "start": 26.9,
           "end": 27.24,
-          "word": " won’t"
+          "word": " won\u2019t"
         },
         {
           "start": 27.24,
@@ -962,8 +852,8 @@
     {
       "id": 40,
       "start": 28.54,
-      "end": 30.02,
-      "text": "Drag off your curtain rail for the",
+      "end": 30.16,
+      "text": "Drag off your curtain rail for the war",
       "words": [
         {
           "start": 28.54,
@@ -999,17 +889,7 @@
           "start": 29.9,
           "end": 30.02,
           "word": " the"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 41,
-      "start": 30.02,
-      "end": 30.16,
-      "text": "war",
-      "words": [
+        },
         {
           "start": 30.02,
           "end": 30.16,
@@ -1107,8 +987,8 @@
     {
       "id": 44,
       "start": 33.6,
-      "end": 35.1,
-      "text": "Flipped the mattress and searched for the",
+      "end": 35.3,
+      "text": "Flipped the mattress and searched for the cash",
       "words": [
         {
           "start": 33.6,
@@ -1144,17 +1024,7 @@
           "start": 35.02,
           "end": 35.1,
           "word": " the"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 45,
-      "start": 35.1,
-      "end": 35.3,
-      "text": "cash",
-      "words": [
+        },
         {
           "start": 35.1,
           "end": 35.3,
@@ -1213,12 +1083,12 @@
       "id": 47,
       "start": 36.88,
       "end": 37.84,
-      "text": "It’s not worth your life,",
+      "text": "It\u2019s not worth your life,",
       "words": [
         {
           "start": 36.88,
           "end": 37.12,
-          "word": " It’s"
+          "word": " It\u2019s"
         },
         {
           "start": 37.12,
@@ -1277,13 +1147,13 @@
     {
       "id": 49,
       "start": 38.62,
-      "end": 40.14,
-      "text": "It’s too late to lock up the",
+      "end": 40.34,
+      "text": "It\u2019s too late to lock up the latch",
       "words": [
         {
           "start": 38.62,
           "end": 39.1,
-          "word": " It’s"
+          "word": " It\u2019s"
         },
         {
           "start": 39.1,
@@ -1314,17 +1184,7 @@
           "start": 40.0,
           "end": 40.14,
           "word": " the"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 50,
-      "start": 40.14,
-      "end": 40.34,
-      "text": "latch",
-      "words": [
+        },
         {
           "start": 40.14,
           "end": 40.34,
@@ -1337,8 +1197,8 @@
     {
       "id": 51,
       "start": 40.34,
-      "end": 41.14,
-      "text": "I can smoke the crow,",
+      "end": 41.6,
+      "text": "I can smoke the crow, relax",
       "words": [
         {
           "start": 40.34,
@@ -1364,17 +1224,7 @@
           "start": 41.0,
           "end": 41.14,
           "word": " crow,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 52,
-      "start": 41.28,
-      "end": 41.6,
-      "text": "relax",
-      "words": [
+        },
         {
           "start": 41.28,
           "end": 41.6,
@@ -1388,12 +1238,12 @@
       "id": 53,
       "start": 42.14,
       "end": 43.64,
-      "text": "I’m not here to control your life",
+      "text": "I\u2019m not here to control your life",
       "words": [
         {
           "start": 42.14,
           "end": 42.5,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 42.5,
@@ -1578,7 +1428,7 @@
       "id": 58,
       "start": 48.08,
       "end": 48.82,
-      "text": "I don’t know why",
+      "text": "I don\u2019t know why",
       "words": [
         {
           "start": 48.08,
@@ -1588,7 +1438,7 @@
         {
           "start": 48.18,
           "end": 48.44,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 48.44,
@@ -1747,8 +1597,8 @@
     {
       "id": 63,
       "start": 53.84,
-      "end": 55.32,
-      "text": "That boy there asked where you gonna",
+      "end": 55.52,
+      "text": "That boy there asked where you gonna die",
       "words": [
         {
           "start": 53.84,
@@ -1784,17 +1634,7 @@
           "start": 55.2,
           "end": 55.32,
           "word": " gonna"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 64,
-      "start": 55.32,
-      "end": 55.52,
-      "text": "die",
-      "words": [
+        },
         {
           "start": 55.32,
           "end": 55.52,
@@ -1805,10 +1645,10 @@
       "instrumental": null
     },
     {
-      "id": 65,
+      "id": 66,
       "start": 55.52,
-      "end": 55.94,
-      "text": "Not bad,",
+      "end": 57.22,
+      "text": "Not bad, your mug don\u2019t fit your guy",
       "words": [
         {
           "start": 55.52,
@@ -1819,17 +1659,7 @@
           "start": 55.7,
           "end": 55.94,
           "word": " bad,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 66,
-      "start": 56.02,
-      "end": 57.22,
-      "text": "your mug don’t fit your guy",
-      "words": [
+        },
         {
           "start": 56.02,
           "end": 56.16,
@@ -1843,7 +1673,7 @@
         {
           "start": 56.38,
           "end": 56.6,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 56.6,
@@ -1898,7 +1728,7 @@
       "id": 68,
       "start": 58.14,
       "end": 58.88,
-      "text": "you won’t be alright",
+      "text": "you won\u2019t be alright",
       "words": [
         {
           "start": 58.14,
@@ -1908,7 +1738,7 @@
         {
           "start": 58.24,
           "end": 58.54,
-          "word": " won’t"
+          "word": " won\u2019t"
         },
         {
           "start": 58.54,
@@ -2142,8 +1972,8 @@
     {
       "id": 75,
       "start": 65.72,
-      "end": 67.06,
-      "text": "Run off to my living room for",
+      "end": 67.4,
+      "text": "Run off to my living room for his life",
       "words": [
         {
           "start": 65.72,
@@ -2179,17 +2009,7 @@
           "start": 66.92,
           "end": 67.06,
           "word": " for"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 76,
-      "start": 67.06,
-      "end": 67.4,
-      "text": "his life",
-      "words": [
+        },
         {
           "start": 67.06,
           "end": 67.16,
@@ -2207,8 +2027,8 @@
     {
       "id": 77,
       "start": 67.4,
-      "end": 68.72,
-      "text": "Slap bro and I got stains of",
+      "end": 69.02,
+      "text": "Slap bro and I got stains of the night",
       "words": [
         {
           "start": 67.4,
@@ -2244,17 +2064,7 @@
           "start": 68.56,
           "end": 68.72,
           "word": " of"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 78,
-      "start": 68.72,
-      "end": 69.02,
-      "text": "the night",
-      "words": [
+        },
         {
           "start": 68.72,
           "end": 68.82,
@@ -2313,12 +2123,12 @@
       "id": 80,
       "start": 70.54,
       "end": 71.6,
-      "text": "I’m sick when I dream about it",
+      "text": "I\u2019m sick when I dream about it",
       "words": [
         {
           "start": 70.54,
           "end": 70.92,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 70.92,
@@ -2358,12 +2168,12 @@
       "id": 81,
       "start": 71.62,
       "end": 72.54,
-      "text": "I’m more sick than them twice",
+      "text": "I\u2019m more sick than them twice",
       "words": [
         {
           "start": 71.62,
           "end": 71.64,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 71.64,
@@ -2397,8 +2207,8 @@
     {
       "id": 82,
       "start": 72.54,
-      "end": 73.72,
-      "text": "What do you know about the rules?",
+      "end": 74.1,
+      "text": "What do you know about the rules? No bars",
       "words": [
         {
           "start": 72.54,
@@ -2434,17 +2244,7 @@
           "start": 73.56,
           "end": 73.72,
           "word": " rules?"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 83,
-      "start": 73.74,
-      "end": 74.1,
-      "text": "No bars",
-      "words": [
+        },
         {
           "start": 73.74,
           "end": 73.88,
@@ -2463,12 +2263,12 @@
       "id": 84,
       "start": 74.1,
       "end": 75.78,
-      "text": "Don’t wanna see man driving his car",
+      "text": "Don\u2019t wanna see man driving his car",
       "words": [
         {
           "start": 74.1,
           "end": 74.58,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 74.58,
@@ -2703,12 +2503,12 @@
       "id": 90,
       "start": 81.74,
       "end": 82.56,
-      "text": "It’s not a bar",
+      "text": "It\u2019s not a bar",
       "words": [
         {
           "start": 81.74,
           "end": 82.1,
-          "word": " It’s"
+          "word": " It\u2019s"
         },
         {
           "start": 82.1,
@@ -2732,8 +2532,8 @@
     {
       "id": 91,
       "start": 83.14,
-      "end": 83.84,
-      "text": "Drag my life",
+      "end": 84.78,
+      "text": "Drag my life Trace",
       "words": [
         {
           "start": 83.14,
@@ -2749,17 +2549,7 @@
           "start": 83.64,
           "end": 83.84,
           "word": " life"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 92,
-      "start": 84.42,
-      "end": 84.78,
-      "text": "Trace",
-      "words": [
+        },
         {
           "start": 84.42,
           "end": 84.78,
@@ -2807,8 +2597,8 @@
     {
       "id": 94,
       "start": 85.92,
-      "end": 87.38,
-      "text": "If you don’t get out of the",
+      "end": 87.6,
+      "text": "If you don\u2019t get out of the car",
       "words": [
         {
           "start": 85.92,
@@ -2823,7 +2613,7 @@
         {
           "start": 86.72,
           "end": 86.9,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 86.9,
@@ -2844,17 +2634,7 @@
           "start": 87.3,
           "end": 87.38,
           "word": " the"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 95,
-      "start": 87.38,
-      "end": 87.6,
-      "text": "car",
-      "words": [
+        },
         {
           "start": 87.38,
           "end": 87.6,
@@ -2868,12 +2648,12 @@
       "id": 96,
       "start": 87.6,
       "end": 89.3,
-      "text": "Don’t wanna see man shooting his star",
+      "text": "Don\u2019t wanna see man shooting his star",
       "words": [
         {
           "start": 87.6,
           "end": 87.98,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 87.98,
@@ -2953,7 +2733,7 @@
       "id": 98,
       "start": 90.94,
       "end": 92.16,
-      "text": "I don’t care if you got friends",
+      "text": "I don\u2019t care if you got friends",
       "words": [
         {
           "start": 90.94,
@@ -2963,7 +2743,7 @@
         {
           "start": 91.32,
           "end": 91.58,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 91.58,
@@ -3168,12 +2948,12 @@
       "id": 104,
       "start": 96.86,
       "end": 97.72,
-      "text": "I’m chasing the farm",
+      "text": "I\u2019m chasing the farm",
       "words": [
         {
           "start": 96.86,
           "end": 97.04,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 97.04,
@@ -3197,8 +2977,8 @@
     {
       "id": 105,
       "start": 97.72,
-      "end": 99.2,
-      "text": "Why didn’t they come back from the",
+      "end": 99.42,
+      "text": "Why didn\u2019t they come back from the start?",
       "words": [
         {
           "start": 97.72,
@@ -3208,7 +2988,7 @@
         {
           "start": 98.06,
           "end": 98.34,
-          "word": " didn’t"
+          "word": " didn\u2019t"
         },
         {
           "start": 98.34,
@@ -3234,17 +3014,7 @@
           "start": 99.1,
           "end": 99.2,
           "word": " the"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 106,
-      "start": 99.2,
-      "end": 99.42,
-      "text": "start?",
-      "words": [
+        },
         {
           "start": 99.2,
           "end": 99.42,
@@ -3302,8 +3072,8 @@
     {
       "id": 108,
       "start": 101.02,
-      "end": 102.44,
-      "text": "While I was playing my bars on",
+      "end": 102.74,
+      "text": "While I was playing my bars on the mic",
       "words": [
         {
           "start": 101.02,
@@ -3339,17 +3109,7 @@
           "start": 102.28,
           "end": 102.44,
           "word": " on"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 109,
-      "start": 102.44,
-      "end": 102.74,
-      "text": "the mic",
-      "words": [
+        },
         {
           "start": 102.44,
           "end": 102.52,
@@ -3365,41 +3125,21 @@
       "instrumental": null
     },
     {
-      "id": 110,
+      "id": 112,
       "start": 102.74,
-      "end": 103.16,
-      "text": "Slap",
+      "end": 106.06,
+      "text": "Slap Kick Now who here wants to fight?",
       "words": [
         {
           "start": 102.74,
           "end": 103.16,
           "word": " Slap"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 111,
-      "start": 104.28,
-      "end": 104.64,
-      "text": "Kick",
-      "words": [
+        },
         {
           "start": 104.28,
           "end": 104.64,
           "word": " Kick"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 112,
-      "start": 104.64,
-      "end": 106.06,
-      "text": "Now who here wants to fight?",
-      "words": [
+        },
         {
           "start": 104.64,
           "end": 105.1,
@@ -3477,8 +3217,8 @@
     {
       "id": 114,
       "start": 107.76,
-      "end": 109.18,
-      "text": "Blacks man’s head with the side of",
+      "end": 109.46,
+      "text": "Blacks man\u2019s head with the side of the mic",
       "words": [
         {
           "start": 107.76,
@@ -3488,7 +3228,7 @@
         {
           "start": 108.3,
           "end": 108.44,
-          "word": " man’s"
+          "word": " man\u2019s"
         },
         {
           "start": 108.44,
@@ -3514,17 +3254,7 @@
           "start": 109.02,
           "end": 109.18,
           "word": " of"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 115,
-      "start": 109.18,
-      "end": 109.46,
-      "text": "the mic",
-      "words": [
+        },
         {
           "start": 109.18,
           "end": 109.24,
@@ -3542,8 +3272,8 @@
     {
       "id": 116,
       "start": 109.46,
-      "end": 110.78,
-      "text": "Jot my shit so no one’s picking",
+      "end": 111.16,
+      "text": "Jot my shit so no one\u2019s picking it light",
       "words": [
         {
           "start": 109.46,
@@ -3573,23 +3303,13 @@
         {
           "start": 110.54,
           "end": 110.64,
-          "word": " one’s"
+          "word": " one\u2019s"
         },
         {
           "start": 110.64,
           "end": 110.78,
           "word": " picking"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 117,
-      "start": 110.78,
-      "end": 111.16,
-      "text": "it light",
-      "words": [
+        },
         {
           "start": 110.78,
           "end": 110.96,
@@ -3607,8 +3327,8 @@
     {
       "id": 118,
       "start": 111.16,
-      "end": 112.52,
-      "text": "Drag my dad to the floor I",
+      "end": 113.44,
+      "text": "Drag my dad to the floor I spite Yo,",
       "words": [
         {
           "start": 111.16,
@@ -3644,32 +3364,12 @@
           "start": 112.42,
           "end": 112.52,
           "word": " I"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 119,
-      "start": 112.52,
-      "end": 112.66,
-      "text": "spite",
-      "words": [
+        },
         {
           "start": 112.52,
           "end": 112.66,
           "word": " spite"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 120,
-      "start": 113.08,
-      "end": 113.44,
-      "text": "Yo,",
-      "words": [
+        },
         {
           "start": 113.08,
           "end": 113.44,
@@ -3757,8 +3457,8 @@
     {
       "id": 123,
       "start": 115.46,
-      "end": 116.1,
-      "text": "I don’t know why",
+      "end": 116.52,
+      "text": "I don\u2019t know why But,",
       "words": [
         {
           "start": 115.46,
@@ -3768,7 +3468,7 @@
         {
           "start": 115.54,
           "end": 115.76,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 115.76,
@@ -3779,17 +3479,7 @@
           "start": 115.88,
           "end": 116.1,
           "word": " why"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 124,
-      "start": 116.1,
-      "end": 116.52,
-      "text": "But,",
-      "words": [
+        },
         {
           "start": 116.1,
           "end": 116.52,
@@ -3967,8 +3657,8 @@
     {
       "id": 130,
       "start": 122.12,
-      "end": 122.88,
-      "text": "I swear he gonna die",
+      "end": 123.38,
+      "text": "I swear he gonna die Not bad,",
       "words": [
         {
           "start": 122.12,
@@ -3994,17 +3684,7 @@
           "start": 122.68,
           "end": 122.88,
           "word": " die"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 131,
-      "start": 122.88,
-      "end": 123.38,
-      "text": "Not bad,",
-      "words": [
+        },
         {
           "start": 122.88,
           "end": 123.08,
@@ -4023,7 +3703,7 @@
       "id": 132,
       "start": 123.42,
       "end": 124.56,
-      "text": "your mug don’t fit your guy",
+      "text": "your mug don\u2019t fit your guy",
       "words": [
         {
           "start": 123.42,
@@ -4038,7 +3718,7 @@
         {
           "start": 123.76,
           "end": 124.0,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 124.0,
@@ -4093,7 +3773,7 @@
       "id": 134,
       "start": 125.56,
       "end": 126.28,
-      "text": "you won’t be alright",
+      "text": "you won\u2019t be alright",
       "words": [
         {
           "start": 125.56,
@@ -4103,7 +3783,7 @@
         {
           "start": 125.66,
           "end": 125.92,
-          "word": " won’t"
+          "word": " won\u2019t"
         },
         {
           "start": 125.92,
@@ -4407,8 +4087,8 @@
     {
       "id": 143,
       "start": 134.84,
-      "end": 136.18,
-      "text": "Fluff bro and I got strings off",
+      "end": 136.5,
+      "text": "Fluff bro and I got strings off the knives",
       "words": [
         {
           "start": 134.84,
@@ -4444,17 +4124,7 @@
           "start": 135.98,
           "end": 136.18,
           "word": " off"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 144,
-      "start": 136.18,
-      "end": 136.5,
-      "text": "the knives",
-      "words": [
+        },
         {
           "start": 136.18,
           "end": 136.26,
@@ -4518,12 +4188,12 @@
       "id": 146,
       "start": 138.04,
       "end": 138.96,
-      "text": "I’m sick when I drink,",
+      "text": "I\u2019m sick when I drink,",
       "words": [
         {
           "start": 138.04,
           "end": 138.32,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 138.32,
@@ -4552,8 +4222,8 @@
     {
       "id": 147,
       "start": 139.0,
-      "end": 139.86,
-      "text": "I won’t think of them twice",
+      "end": 140.4,
+      "text": "I won\u2019t think of them twice Danger,",
       "words": [
         {
           "start": 139.0,
@@ -4563,7 +4233,7 @@
         {
           "start": 139.06,
           "end": 139.22,
-          "word": " won’t"
+          "word": " won\u2019t"
         },
         {
           "start": 139.22,
@@ -4584,17 +4254,7 @@
           "start": 139.6,
           "end": 139.86,
           "word": " twice"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 148,
-      "start": 139.86,
-      "end": 140.4,
-      "text": "Danger,",
-      "words": [
+        },
         {
           "start": 139.86,
           "end": 140.4,
@@ -4633,12 +4293,12 @@
       "id": 150,
       "start": 141.42,
       "end": 143.22,
-      "text": "Don’t know we got the shotgun there",
+      "text": "Don\u2019t know we got the shotgun there",
       "words": [
         {
           "start": 141.42,
           "end": 142.08,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 142.08,
@@ -4677,8 +4337,8 @@
     {
       "id": 151,
       "start": 143.22,
-      "end": 144.68,
-      "text": "Cutting man down from the side of",
+      "end": 145.02,
+      "text": "Cutting man down from the side of the stairs",
       "words": [
         {
           "start": 143.22,
@@ -4714,17 +4374,7 @@
           "start": 144.54,
           "end": 144.68,
           "word": " of"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 152,
-      "start": 144.68,
-      "end": 145.02,
-      "text": "the stairs",
-      "words": [
+        },
         {
           "start": 144.68,
           "end": 144.72,
@@ -4740,10 +4390,10 @@
       "instrumental": null
     },
     {
-      "id": 153,
+      "id": 154,
       "start": 147.58,
-      "end": 148.36,
-      "text": "Trust me",
+      "end": 154.26,
+      "text": "Trust me Next time You mad Teeempz Yeah, yeah,",
       "words": [
         {
           "start": 147.58,
@@ -4754,17 +4404,7 @@
           "start": 147.98,
           "end": 148.36,
           "word": " me"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 154,
-      "start": 148.36,
-      "end": 149.28,
-      "text": "Next time",
-      "words": [
+        },
         {
           "start": 148.36,
           "end": 148.84,
@@ -4774,17 +4414,7 @@
           "start": 148.84,
           "end": 149.28,
           "word": " time"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 155,
-      "start": 149.28,
-      "end": 150.38,
-      "text": "You mad",
-      "words": [
+        },
         {
           "start": 149.28,
           "end": 150.04,
@@ -4794,47 +4424,17 @@
           "start": 150.04,
           "end": 150.38,
           "word": " mad"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 156,
-      "start": 151.3,
-      "end": 151.7,
-      "text": "Teeempz",
-      "words": [
+        },
         {
           "start": 151.3,
           "end": 151.7,
           "word": " Teeempz"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 157,
-      "start": 153.6,
-      "end": 154.0,
-      "text": "Yeah,",
-      "words": [
+        },
         {
           "start": 153.6,
           "end": 154.0,
           "word": " Yeah,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 158,
-      "start": 154.0,
-      "end": 154.26,
-      "text": "yeah,",
-      "words": [
+        },
         {
           "start": 154.0,
           "end": 154.26,
@@ -4845,41 +4445,21 @@
       "instrumental": null
     },
     {
-      "id": 159,
+      "id": 161,
       "start": 154.26,
-      "end": 154.54,
-      "text": "yeah,",
+      "end": 155.0,
+      "text": "yeah, yeah, yeah",
       "words": [
         {
           "start": 154.26,
           "end": 154.54,
           "word": " yeah,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 160,
-      "start": 154.54,
-      "end": 154.8,
-      "text": "yeah,",
-      "words": [
+        },
         {
           "start": 154.54,
           "end": 154.8,
           "word": " yeah,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 161,
-      "start": 154.8,
-      "end": 155.0,
-      "text": "yeah",
-      "words": [
+        },
         {
           "start": 154.8,
           "end": 155.0,
@@ -4892,13 +4472,13 @@
     {
       "id": 162,
       "start": 155.0,
-      "end": 155.7,
-      "text": "I’m still about",
+      "end": 158.8,
+      "text": "I\u2019m still about Smiles Alright,",
       "words": [
         {
           "start": 155.0,
           "end": 155.24,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 155.24,
@@ -4909,32 +4489,12 @@
           "start": 155.46,
           "end": 155.7,
           "word": " about"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 163,
-      "start": 157.58,
-      "end": 157.98,
-      "text": "Smiles",
-      "words": [
+        },
         {
           "start": 157.58,
           "end": 157.98,
           "word": " Smiles"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 164,
-      "start": 158.4,
-      "end": 158.8,
-      "text": "Alright,",
-      "words": [
+        },
         {
           "start": 158.4,
           "end": 158.8,
@@ -4948,12 +4508,12 @@
       "id": 165,
       "start": 158.88,
       "end": 159.4,
-      "text": "I’m gonna come back",
+      "text": "I\u2019m gonna come back",
       "words": [
         {
           "start": 158.88,
           "end": 159.08,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 159.08,
@@ -5012,13 +4572,13 @@
     {
       "id": 167,
       "start": 160.06,
-      "end": 161.24,
-      "text": "Won’t get none of your CD’s",
+      "end": 161.56,
+      "text": "Won\u2019t get none of your CD\u2019s Yo",
       "words": [
         {
           "start": 160.06,
           "end": 160.36,
-          "word": " Won’t"
+          "word": " Won\u2019t"
         },
         {
           "start": 160.36,
@@ -5043,18 +4603,8 @@
         {
           "start": 160.82,
           "end": 161.24,
-          "word": " CD’s"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 168,
-      "start": 161.24,
-      "end": 161.56,
-      "text": "Yo",
-      "words": [
+          "word": " CD\u2019s"
+        },
         {
           "start": 161.24,
           "end": 161.56,
@@ -5093,12 +4643,12 @@
       "id": 170,
       "start": 163.36,
       "end": 164.84,
-      "text": "Don’t know we got the shotgun there",
+      "text": "Don\u2019t know we got the shotgun there",
       "words": [
         {
           "start": 163.36,
           "end": 163.56,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 163.56,
@@ -5137,8 +4687,8 @@
     {
       "id": 171,
       "start": 164.84,
-      "end": 166.22,
-      "text": "Cutting man down from the side of",
+      "end": 166.44,
+      "text": "Cutting man down from the side of the stairs",
       "words": [
         {
           "start": 164.84,
@@ -5174,17 +4724,7 @@
           "start": 166.12,
           "end": 166.22,
           "word": " of"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 172,
-      "start": 166.22,
-      "end": 166.44,
-      "text": "the stairs",
-      "words": [
+        },
         {
           "start": 166.22,
           "end": 166.28,
@@ -5202,8 +4742,8 @@
     {
       "id": 173,
       "start": 166.44,
-      "end": 167.96,
-      "text": "See that man trying to run over",
+      "end": 168.24,
+      "text": "See that man trying to run over there",
       "words": [
         {
           "start": 166.44,
@@ -5239,17 +4779,7 @@
           "start": 167.74,
           "end": 167.96,
           "word": " over"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 174,
-      "start": 167.96,
-      "end": 168.24,
-      "text": "there",
-      "words": [
+        },
         {
           "start": 167.96,
           "end": 168.24,
@@ -5263,7 +4793,7 @@
       "id": 175,
       "start": 168.24,
       "end": 169.28,
-      "text": "Cut off the man’s teeth,",
+      "text": "Cut off the man\u2019s teeth,",
       "words": [
         {
           "start": 168.24,
@@ -5283,7 +4813,7 @@
         {
           "start": 168.9,
           "end": 169.1,
-          "word": " man’s"
+          "word": " man\u2019s"
         },
         {
           "start": 169.1,
@@ -5347,8 +4877,8 @@
     {
       "id": 178,
       "start": 170.74,
-      "end": 171.64,
-      "text": "came out over there",
+      "end": 172.04,
+      "text": "came out over there Whoa",
       "words": [
         {
           "start": 170.74,
@@ -5369,17 +4899,7 @@
           "start": 171.36,
           "end": 171.64,
           "word": " there"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 179,
-      "start": 171.64,
-      "end": 172.04,
-      "text": "Whoa",
-      "words": [
+        },
         {
           "start": 171.64,
           "end": 172.04,
@@ -5457,8 +4977,8 @@
     {
       "id": 182,
       "start": 174.16,
-      "end": 174.98,
-      "text": "now he down there",
+      "end": 175.6,
+      "text": "now he down there So",
       "words": [
         {
           "start": 174.16,
@@ -5479,17 +4999,7 @@
           "start": 174.7,
           "end": 174.98,
           "word": " there"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 183,
-      "start": 174.98,
-      "end": 175.6,
-      "text": "So",
-      "words": [
+        },
         {
           "start": 174.98,
           "end": 175.6,
@@ -5503,12 +5013,12 @@
       "id": 184,
       "start": 175.6,
       "end": 176.48,
-      "text": "Don’t come downstairs",
+      "text": "Don\u2019t come downstairs",
       "words": [
         {
           "start": 175.6,
           "end": 175.94,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 175.94,
@@ -5527,8 +5037,8 @@
     {
       "id": 185,
       "start": 176.48,
-      "end": 177.52,
-      "text": "Now he over the",
+      "end": 178.94,
+      "text": "Now he over the Yo, stay down",
       "words": [
         {
           "start": 176.48,
@@ -5549,32 +5059,12 @@
           "start": 177.3,
           "end": 177.52,
           "word": " the"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 186,
-      "start": 177.52,
-      "end": 178.0,
-      "text": "Yo,",
-      "words": [
+        },
         {
           "start": 177.52,
           "end": 178.0,
           "word": " Yo,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 187,
-      "start": 178.46,
-      "end": 178.94,
-      "text": "stay down",
-      "words": [
+        },
         {
           "start": 178.46,
           "end": 178.58,
@@ -5632,13 +5122,13 @@
     {
       "id": 189,
       "start": 180.02,
-      "end": 181.44,
-      "text": "Don’t know he off the air top",
+      "end": 182.1,
+      "text": "Don\u2019t know he off the air top here Yo,",
       "words": [
         {
           "start": 180.02,
           "end": 180.42,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 180.42,
@@ -5669,32 +5159,12 @@
           "start": 181.22,
           "end": 181.44,
           "word": " top"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 190,
-      "start": 181.44,
-      "end": 181.64,
-      "text": "here",
-      "words": [
+        },
         {
           "start": 181.44,
           "end": 181.64,
           "word": " here"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 191,
-      "start": 181.64,
-      "end": 182.1,
-      "text": "Yo,",
-      "words": [
+        },
         {
           "start": 181.64,
           "end": 182.1,
@@ -5748,7 +5218,7 @@
       "id": 193,
       "start": 183.4,
       "end": 185.12,
-      "text": "This year it’s kicking off right here",
+      "text": "This year it\u2019s kicking off right here",
       "words": [
         {
           "start": 183.4,
@@ -5763,7 +5233,7 @@
         {
           "start": 183.96,
           "end": 184.22,
-          "word": " it’s"
+          "word": " it\u2019s"
         },
         {
           "start": 184.22,
@@ -5793,7 +5263,7 @@
       "id": 194,
       "start": 185.12,
       "end": 186.84,
-      "text": "This year it’s kicking off right here",
+      "text": "This year it\u2019s kicking off right here",
       "words": [
         {
           "start": 185.12,
@@ -5808,7 +5278,7 @@
         {
           "start": 185.66,
           "end": 185.9,
-          "word": " it’s"
+          "word": " it\u2019s"
         },
         {
           "start": 185.9,
@@ -5837,13 +5307,13 @@
     {
       "id": 195,
       "start": 186.84,
-      "end": 188.46,
-      "text": "Don’t know we got the shotgun there",
+      "end": 189.16,
+      "text": "Don\u2019t know we got the shotgun there Hey",
       "words": [
         {
           "start": 186.84,
           "end": 187.18,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 187.18,
@@ -5874,17 +5344,7 @@
           "start": 188.08,
           "end": 188.46,
           "word": " there"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 196,
-      "start": 188.46,
-      "end": 189.16,
-      "text": "Hey",
-      "words": [
+        },
         {
           "start": 188.46,
           "end": 189.16,
@@ -5897,8 +5357,8 @@
     {
       "id": 197,
       "start": 189.16,
-      "end": 190.22,
-      "text": "If I go make me a boss",
+      "end": 190.82,
+      "text": "If I go make me a boss No one",
       "words": [
         {
           "start": 189.16,
@@ -5934,17 +5394,7 @@
           "start": 189.94,
           "end": 190.22,
           "word": " boss"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 198,
-      "start": 190.22,
-      "end": 190.82,
-      "text": "No one",
-      "words": [
+        },
         {
           "start": 190.22,
           "end": 190.66,
@@ -6023,12 +5473,12 @@
       "id": 201,
       "start": 192.74,
       "end": 193.52,
-      "text": "I’m boy off the ting",
+      "text": "I\u2019m boy off the ting",
       "words": [
         {
           "start": 192.74,
           "end": 192.94,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 192.94,
@@ -6082,13 +5532,13 @@
     {
       "id": 203,
       "start": 194.4,
-      "end": 195.26,
-      "text": "I’m boy off the ting",
+      "end": 195.64,
+      "text": "I\u2019m boy off the ting Whoa",
       "words": [
         {
           "start": 194.4,
           "end": 194.62,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 194.62,
@@ -6109,17 +5559,7 @@
           "start": 195.0,
           "end": 195.26,
           "word": " ting"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 204,
-      "start": 195.26,
-      "end": 195.64,
-      "text": "Whoa",
-      "words": [
+        },
         {
           "start": 195.26,
           "end": 195.64,
@@ -6222,13 +5662,13 @@
     {
       "id": 208,
       "start": 199.52,
-      "end": 200.26,
-      "text": "I’m boy off the ting",
+      "end": 200.72,
+      "text": "I\u2019m boy off the ting Yo, please",
       "words": [
         {
           "start": 199.52,
           "end": 199.7,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 199.7,
@@ -6249,32 +5689,12 @@
           "start": 200.06,
           "end": 200.26,
           "word": " ting"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 209,
-      "start": 200.26,
-      "end": 200.48,
-      "text": "Yo,",
-      "words": [
+        },
         {
           "start": 200.26,
           "end": 200.48,
           "word": " Yo,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 210,
-      "start": 200.48,
-      "end": 200.72,
-      "text": "please",
-      "words": [
+        },
         {
           "start": 200.48,
           "end": 200.72,
@@ -6347,8 +5767,8 @@
     {
       "id": 213,
       "start": 204.6,
-      "end": 205.34,
-      "text": "I don’t know why",
+      "end": 205.76,
+      "text": "I don\u2019t know why Fuck",
       "words": [
         {
           "start": 204.6,
@@ -6358,7 +5778,7 @@
         {
           "start": 204.72,
           "end": 204.94,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 204.94,
@@ -6369,17 +5789,7 @@
           "start": 205.06,
           "end": 205.34,
           "word": " why"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 214,
-      "start": 205.34,
-      "end": 205.76,
-      "text": "Fuck",
-      "words": [
+        },
         {
           "start": 205.34,
           "end": 205.76,
@@ -6422,8 +5832,8 @@
     {
       "id": 216,
       "start": 208.1,
-      "end": 208.7,
-      "text": "just in the disguise",
+      "end": 209.2,
+      "text": "just in the disguise Oh",
       "words": [
         {
           "start": 208.1,
@@ -6444,17 +5854,7 @@
           "start": 208.46,
           "end": 208.7,
           "word": " disguise"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 217,
-      "start": 208.7,
-      "end": 209.2,
-      "text": "Oh",
-      "words": [
+        },
         {
           "start": 208.7,
           "end": 209.2,
@@ -6528,12 +5928,12 @@
       "id": 220,
       "start": 212.84,
       "end": 213.84,
-      "text": "Don’t be your guy",
+      "text": "Don\u2019t be your guy",
       "words": [
         {
           "start": 212.84,
           "end": 213.22,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 213.22,
@@ -6588,7 +5988,7 @@
       "id": 222,
       "start": 214.7,
       "end": 215.46,
-      "text": "you won’t be alright",
+      "text": "you won\u2019t be alright",
       "words": [
         {
           "start": 214.7,
@@ -6598,7 +5998,7 @@
         {
           "start": 214.86,
           "end": 215.04,
-          "word": " won’t"
+          "word": " won\u2019t"
         },
         {
           "start": 215.04,
@@ -6648,7 +6048,7 @@
       "id": 224,
       "start": 217.42,
       "end": 217.42,
-      "text": "you won’t be alright",
+      "text": "you won\u2019t be alright",
       "words": [
         {
           "start": 217.42,
@@ -6658,7 +6058,7 @@
         {
           "start": 217.42,
           "end": 217.42,
-          "word": " won’t"
+          "word": " won\u2019t"
         },
         {
           "start": 217.42,
@@ -6708,7 +6108,7 @@
       "id": 226,
       "start": 218.44,
       "end": 218.44,
-      "text": "you won’t be alright",
+      "text": "you won\u2019t be alright",
       "words": [
         {
           "start": 218.44,
@@ -6718,7 +6118,7 @@
         {
           "start": 218.44,
           "end": 218.44,
-          "word": " won’t"
+          "word": " won\u2019t"
         },
         {
           "start": 218.44,
@@ -6738,12 +6138,12 @@
       "id": 227,
       "start": 218.44,
       "end": 218.98,
-      "text": "I’m the boss of a life",
+      "text": "I\u2019m the boss of a life",
       "words": [
         {
           "start": 218.44,
           "end": 218.44,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 218.44,
@@ -6778,12 +6178,12 @@
       "id": 228,
       "start": 220.3,
       "end": 221.04,
-      "text": "I’m a far",
+      "text": "I\u2019m a far",
       "words": [
         {
           "start": 220.3,
           "end": 220.7,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 220.7,
@@ -6803,7 +6203,7 @@
       "id": 229,
       "start": 221.04,
       "end": 234.06,
-      "text": "The Black Nigerian’s way too heavy",
+      "text": "The Black Nigerian\u2019s way too heavy",
       "words": [
         {
           "start": 221.04,
@@ -6818,7 +6218,7 @@
         {
           "start": 226.88,
           "end": 233.38,
-          "word": " Nigerian’s"
+          "word": " Nigerian\u2019s"
         },
         {
           "start": 233.38,
@@ -6842,8 +6242,8 @@
     {
       "id": 230,
       "start": 234.06,
-      "end": 235.3,
-      "text": "Everytime I open my mouth,",
+      "end": 235.5,
+      "text": "Everytime I open my mouth, blood",
       "words": [
         {
           "start": 234.06,
@@ -6869,17 +6269,7 @@
           "start": 235.1,
           "end": 235.3,
           "word": " mouth,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 231,
-      "start": 235.36,
-      "end": 235.5,
-      "text": "blood",
-      "words": [
+        },
         {
           "start": 235.36,
           "end": 235.5,
@@ -6892,8 +6282,8 @@
     {
       "id": 232,
       "start": 235.5,
-      "end": 236.82,
-      "text": "I see a lyric and another MC",
+      "end": 237.5,
+      "text": "I see a lyric and another MC gets buried",
       "words": [
         {
           "start": 235.5,
@@ -6929,17 +6319,7 @@
           "start": 236.48,
           "end": 236.82,
           "word": " MC"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 233,
-      "start": 236.82,
-      "end": 237.5,
-      "text": "gets buried",
-      "words": [
+        },
         {
           "start": 236.82,
           "end": 237.14,
@@ -6955,26 +6335,16 @@
       "instrumental": null
     },
     {
-      "id": 234,
+      "id": 235,
       "start": 237.5,
-      "end": 238.2,
-      "text": "Yeah",
+      "end": 239.18,
+      "text": "Yeah Six feet under",
       "words": [
         {
           "start": 237.5,
           "end": 238.2,
           "word": " Yeah"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 235,
-      "start": 238.2,
-      "end": 239.18,
-      "text": "Six feet under",
-      "words": [
+        },
         {
           "start": 238.2,
           "end": 238.6,
@@ -7082,8 +6452,8 @@
     {
       "id": 238,
       "start": 241.76,
-      "end": 242.48,
-      "text": "a private number",
+      "end": 243.08,
+      "text": "a private number Ring ring",
       "words": [
         {
           "start": 241.76,
@@ -7099,17 +6469,7 @@
           "start": 242.12,
           "end": 242.48,
           "word": " number"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 239,
-      "start": 242.48,
-      "end": 243.08,
-      "text": "Ring ring",
-      "words": [
+        },
         {
           "start": 242.48,
           "end": 242.92,
@@ -7127,8 +6487,8 @@
     {
       "id": 240,
       "start": 243.08,
-      "end": 244.06,
-      "text": "Talk to the Answer Machine",
+      "end": 245.02,
+      "text": "Talk to the Answer Machine Yo Test",
       "words": [
         {
           "start": 243.08,
@@ -7154,32 +6514,12 @@
           "start": 243.78,
           "end": 244.06,
           "word": " Machine"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 241,
-      "start": 244.06,
-      "end": 244.56,
-      "text": "Yo",
-      "words": [
+        },
         {
           "start": 244.06,
           "end": 244.56,
           "word": " Yo"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 242,
-      "start": 244.56,
-      "end": 245.02,
-      "text": "Test",
-      "words": [
+        },
         {
           "start": 244.56,
           "end": 245.02,
@@ -7242,8 +6582,8 @@
     {
       "id": 245,
       "start": 246.24,
-      "end": 247.26,
-      "text": "I just wanna do my part for",
+      "end": 247.54,
+      "text": "I just wanna do my part for the scene",
       "words": [
         {
           "start": 246.24,
@@ -7279,17 +6619,7 @@
           "start": 247.02,
           "end": 247.26,
           "word": " for"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 246,
-      "start": 247.26,
-      "end": 247.54,
-      "text": "the scene",
-      "words": [
+        },
         {
           "start": 247.26,
           "end": 247.34,
@@ -7308,12 +6638,12 @@
       "id": 247,
       "start": 247.54,
       "end": 248.42,
-      "text": "I’m a big man but they’re like",
+      "text": "I\u2019m a big man but they\u2019re like",
       "words": [
         {
           "start": 247.54,
           "end": 247.74,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 247.74,
@@ -7338,7 +6668,7 @@
         {
           "start": 248.3,
           "end": 248.42,
-          "word": " they’re"
+          "word": " they\u2019re"
         },
         {
           "start": 248.42,
@@ -7352,8 +6682,8 @@
     {
       "id": 248,
       "start": 248.44,
-      "end": 249.12,
-      "text": "I don’t wanna see me act like",
+      "end": 249.56,
+      "text": "I don\u2019t wanna see me act like I\u2019m 15",
       "words": [
         {
           "start": 248.44,
@@ -7363,7 +6693,7 @@
         {
           "start": 248.44,
           "end": 248.44,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 248.44,
@@ -7389,21 +6719,11 @@
           "start": 248.98,
           "end": 249.12,
           "word": " like"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 249,
-      "start": 249.12,
-      "end": 249.56,
-      "text": "I’m 15",
-      "words": [
+        },
         {
           "start": 249.12,
           "end": 249.3,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 249.3,
@@ -7415,30 +6735,20 @@
       "instrumental": null
     },
     {
-      "id": 250,
+      "id": 251,
       "start": 249.56,
-      "end": 250.12,
-      "text": "Tramp,",
+      "end": 250.9,
+      "text": "Tramp, it\u2019s a big man ting",
       "words": [
         {
           "start": 249.56,
           "end": 250.12,
           "word": " Tramp,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 251,
-      "start": 250.14,
-      "end": 250.9,
-      "text": "it’s a big man ting",
-      "words": [
+        },
         {
           "start": 250.14,
           "end": 250.3,
-          "word": " it’s"
+          "word": " it\u2019s"
         },
         {
           "start": 250.3,
@@ -7468,7 +6778,7 @@
       "id": 252,
       "start": 250.9,
       "end": 252.6,
-      "text": "Please stop watching the whip man’s in",
+      "text": "Please stop watching the whip man\u2019s in",
       "words": [
         {
           "start": 250.9,
@@ -7498,7 +6808,7 @@
         {
           "start": 252.18,
           "end": 252.46,
-          "word": " man’s"
+          "word": " man\u2019s"
         },
         {
           "start": 252.46,
@@ -7512,8 +6822,8 @@
     {
       "id": 253,
       "start": 252.6,
-      "end": 254.12,
-      "text": "I don’t wanna be no funky ass",
+      "end": 254.34,
+      "text": "I don\u2019t wanna be no funky ass DJ",
       "words": [
         {
           "start": 252.6,
@@ -7523,7 +6833,7 @@
         {
           "start": 252.94,
           "end": 253.12,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 253.12,
@@ -7549,17 +6859,7 @@
           "start": 253.84,
           "end": 254.12,
           "word": " ass"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 254,
-      "start": 254.12,
-      "end": 254.34,
-      "text": "DJ",
-      "words": [
+        },
         {
           "start": 254.12,
           "end": 254.34,
@@ -7570,10 +6870,10 @@
       "instrumental": null
     },
     {
-      "id": 255,
+      "id": 256,
       "start": 254.34,
-      "end": 254.88,
-      "text": "But man,",
+      "end": 255.34,
+      "text": "But man, I got me on a",
       "words": [
         {
           "start": 254.34,
@@ -7584,17 +6884,7 @@
           "start": 254.68,
           "end": 254.88,
           "word": " man,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 256,
-      "start": 254.88,
-      "end": 255.34,
-      "text": "I got me on a",
-      "words": [
+        },
         {
           "start": 254.88,
           "end": 254.98,
@@ -7910,10 +7200,10 @@
       "instrumental": null
     },
     {
-      "id": 269,
+      "id": 271,
       "start": 269.4,
-      "end": 271.24,
-      "text": "Yes, Lord",
+      "end": 277.38,
+      "text": "Yes, Lord Yeah Yeah",
       "words": [
         {
           "start": 269.4,
@@ -7924,32 +7214,12 @@
           "start": 270.96,
           "end": 271.24,
           "word": " Lord"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 271,
-      "start": 275.72,
-      "end": 276.24,
-      "text": "Yeah",
-      "words": [
+        },
         {
           "start": 275.72,
           "end": 276.24,
           "word": " Yeah"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 272,
-      "start": 276.98,
-      "end": 277.38,
-      "text": "Yeah",
-      "words": [
+        },
         {
           "start": 276.98,
           "end": 277.38,
@@ -7963,12 +7233,12 @@
       "id": 273,
       "start": 277.38,
       "end": 278.8,
-      "text": "It’s a high ting inside",
+      "text": "It\u2019s a high ting inside",
       "words": [
         {
           "start": 277.38,
           "end": 278.02,
-          "word": " It’s"
+          "word": " It\u2019s"
         },
         {
           "start": 278.02,
@@ -8050,10 +7320,10 @@
       "instrumental": null
     },
     {
-      "id": 277,
+      "id": 278,
       "start": 283.02,
-      "end": 283.88,
-      "text": "Go home",
+      "end": 284.74,
+      "text": "Go home Look in the mirror",
       "words": [
         {
           "start": 283.02,
@@ -8064,17 +7334,7 @@
           "start": 283.6,
           "end": 283.88,
           "word": " home"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 278,
-      "start": 283.88,
-      "end": 284.74,
-      "text": "Look in the mirror",
-      "words": [
+        },
         {
           "start": 283.88,
           "end": 284.22,
@@ -8103,7 +7363,7 @@
       "id": 279,
       "start": 284.74,
       "end": 285.9,
-      "text": "Realise no one’s scared",
+      "text": "Realise no one\u2019s scared",
       "words": [
         {
           "start": 284.74,
@@ -8118,7 +7378,7 @@
         {
           "start": 285.46,
           "end": 285.72,
-          "word": " one’s"
+          "word": " one\u2019s"
         },
         {
           "start": 285.72,
@@ -8248,12 +7508,12 @@
       "id": 284,
       "start": 289.3,
       "end": 290.24,
-      "text": "You’re not hench",
+      "text": "You\u2019re not hench",
       "words": [
         {
           "start": 289.3,
           "end": 289.78,
-          "word": " You’re"
+          "word": " You\u2019re"
         },
         {
           "start": 289.78,
@@ -8273,12 +7533,12 @@
       "id": 285,
       "start": 290.24,
       "end": 291.04,
-      "text": "You’re not bad",
+      "text": "You\u2019re not bad",
       "words": [
         {
           "start": 290.24,
           "end": 290.66,
-          "word": " You’re"
+          "word": " You\u2019re"
         },
         {
           "start": 290.66,
@@ -8297,8 +7557,8 @@
     {
       "id": 286,
       "start": 291.04,
-      "end": 292.44,
-      "text": "You just grew up your face all",
+      "end": 292.72,
+      "text": "You just grew up your face all red",
       "words": [
         {
           "start": 291.04,
@@ -8334,17 +7594,7 @@
           "start": 292.28,
           "end": 292.44,
           "word": " all"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 287,
-      "start": 292.44,
-      "end": 292.72,
-      "text": "red",
-      "words": [
+        },
         {
           "start": 292.44,
           "end": 292.72,
@@ -8357,8 +7607,8 @@
     {
       "id": 288,
       "start": 292.72,
-      "end": 293.94,
-      "text": "Trying to get high off me,",
+      "end": 294.34,
+      "text": "Trying to get high off me, Get air",
       "words": [
         {
           "start": 292.72,
@@ -8389,17 +7639,7 @@
           "start": 293.72,
           "end": 293.94,
           "word": " me,"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 289,
-      "start": 294.0,
-      "end": 294.34,
-      "text": "Get air",
-      "words": [
+        },
         {
           "start": 294.0,
           "end": 294.14,
@@ -8417,8 +7657,8 @@
     {
       "id": 290,
       "start": 294.34,
-      "end": 295.68,
-      "text": "Trying to get high off me,",
+      "end": 295.96,
+      "text": "Trying to get high off me, air",
       "words": [
         {
           "start": 294.34,
@@ -8449,17 +7689,7 @@
           "start": 295.38,
           "end": 295.68,
           "word": " me,"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 291,
-      "start": 295.68,
-      "end": 295.96,
-      "text": "air",
-      "words": [
+        },
         {
           "start": 295.68,
           "end": 295.96,
@@ -8527,8 +7757,8 @@
     {
       "id": 294,
       "start": 297.66,
-      "end": 299.24,
-      "text": "Nobody cares what you got in your",
+      "end": 299.44,
+      "text": "Nobody cares what you got in your hand",
       "words": [
         {
           "start": 297.66,
@@ -8564,17 +7794,7 @@
           "start": 299.12,
           "end": 299.24,
           "word": " your"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 295,
-      "start": 299.24,
-      "end": 299.44,
-      "text": "hand",
-      "words": [
+        },
         {
           "start": 299.24,
           "end": 299.44,
@@ -8587,8 +7807,8 @@
     {
       "id": 296,
       "start": 299.44,
-      "end": 300.88,
-      "text": "Nobody cares what you got in your",
+      "end": 301.08,
+      "text": "Nobody cares what you got in your jeans",
       "words": [
         {
           "start": 299.44,
@@ -8624,17 +7844,7 @@
           "start": 300.78,
           "end": 300.88,
           "word": " your"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 297,
-      "start": 300.88,
-      "end": 301.08,
-      "text": "jeans",
-      "words": [
+        },
         {
           "start": 300.88,
           "end": 301.08,
@@ -8692,8 +7902,8 @@
     {
       "id": 299,
       "start": 302.16,
-      "end": 302.68,
-      "text": "the phone screen",
+      "end": 303.1,
+      "text": "the phone screen Yo",
       "words": [
         {
           "start": 302.16,
@@ -8709,17 +7919,7 @@
           "start": 302.48,
           "end": 302.68,
           "word": " screen"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 300,
-      "start": 302.68,
-      "end": 303.1,
-      "text": "Yo",
-      "words": [
+        },
         {
           "start": 302.68,
           "end": 303.1,
@@ -8733,12 +7933,12 @@
       "id": 301,
       "start": 303.1,
       "end": 304.42,
-      "text": "Don’t bring war to the king",
+      "text": "Don\u2019t bring war to the king",
       "words": [
         {
           "start": 303.1,
           "end": 303.68,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 303.68,
@@ -8772,13 +7972,13 @@
     {
       "id": 302,
       "start": 304.42,
-      "end": 305.92,
-      "text": "Don’t tell me about draw for the",
+      "end": 306.1,
+      "text": "Don\u2019t tell me about draw for the ting",
       "words": [
         {
           "start": 304.42,
           "end": 304.88,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 304.88,
@@ -8809,17 +8009,7 @@
           "start": 305.78,
           "end": 305.92,
           "word": " the"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 303,
-      "start": 305.92,
-      "end": 306.1,
-      "text": "ting",
-      "words": [
+        },
         {
           "start": 305.92,
           "end": 306.1,
@@ -8830,10 +8020,10 @@
       "instrumental": null
     },
     {
-      "id": 304,
+      "id": 305,
       "start": 306.1,
-      "end": 306.4,
-      "text": "Trust me",
+      "end": 306.46,
+      "text": "Trust me Yo",
       "words": [
         {
           "start": 306.1,
@@ -8844,17 +8034,7 @@
           "start": 306.26,
           "end": 306.4,
           "word": " me"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 305,
-      "start": 306.4,
-      "end": 306.46,
-      "text": "Yo",
-      "words": [
+        },
         {
           "start": 306.4,
           "end": 306.46,
@@ -8922,8 +8102,8 @@
     {
       "id": 308,
       "start": 308.2,
-      "end": 309.46,
-      "text": "You get charged more for your trim",
+      "end": 309.86,
+      "text": "You get charged more for your trim Say",
       "words": [
         {
           "start": 308.2,
@@ -8959,17 +8139,7 @@
           "start": 309.28,
           "end": 309.46,
           "word": " trim"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 309,
-      "start": 309.46,
-      "end": 309.86,
-      "text": "Say",
-      "words": [
+        },
         {
           "start": 309.46,
           "end": 309.86,
@@ -8982,8 +8152,8 @@
     {
       "id": 310,
       "start": 309.86,
-      "end": 311.14,
-      "text": "You wanna say him but there’s really",
+      "end": 311.56,
+      "text": "You wanna say him but there\u2019s really no him",
       "words": [
         {
           "start": 309.86,
@@ -9013,23 +8183,13 @@
         {
           "start": 310.88,
           "end": 311.0,
-          "word": " there’s"
+          "word": " there\u2019s"
         },
         {
           "start": 311.0,
           "end": 311.14,
           "word": " really"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 311,
-      "start": 311.14,
-      "end": 311.56,
-      "text": "no him",
-      "words": [
+        },
         {
           "start": 311.14,
           "end": 311.3,
@@ -9045,26 +8205,16 @@
       "instrumental": null
     },
     {
-      "id": 312,
+      "id": 313,
       "start": 311.56,
-      "end": 311.76,
-      "text": "Him",
+      "end": 313.26,
+      "text": "Him Wanna talk hard but you really no brim",
       "words": [
         {
           "start": 311.56,
           "end": 311.76,
           "word": " Him"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 313,
-      "start": 311.76,
-      "end": 312.98,
-      "text": "Wanna talk hard but you really no",
-      "words": [
+        },
         {
           "start": 311.76,
           "end": 311.96,
@@ -9099,17 +8249,7 @@
           "start": 312.84,
           "end": 312.98,
           "word": " no"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 314,
-      "start": 312.98,
-      "end": 313.26,
-      "text": "brim",
-      "words": [
+        },
         {
           "start": 312.98,
           "end": 313.26,
@@ -9120,26 +8260,16 @@
       "instrumental": null
     },
     {
-      "id": 315,
+      "id": 316,
       "start": 313.26,
-      "end": 313.54,
-      "text": "Brim",
+      "end": 314.5,
+      "text": "Brim Brought a kind heart but I can\u2019t",
       "words": [
         {
           "start": 313.26,
           "end": 313.54,
           "word": " Brim"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 316,
-      "start": 313.54,
-      "end": 314.5,
-      "text": "Brought a kind heart but I can’t",
-      "words": [
+        },
         {
           "start": 313.54,
           "end": 313.64,
@@ -9173,17 +8303,17 @@
         {
           "start": 314.28,
           "end": 314.5,
-          "word": " can’t"
+          "word": " can\u2019t"
         }
       ],
       "speaker": "Tempa T",
       "instrumental": null
     },
     {
-      "id": 317,
+      "id": 318,
       "start": 314.5,
-      "end": 314.84,
-      "text": "get dim",
+      "end": 315.04,
+      "text": "get dim What?",
       "words": [
         {
           "start": 314.5,
@@ -9194,17 +8324,7 @@
           "start": 314.64,
           "end": 314.84,
           "word": " dim"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 318,
-      "start": 314.84,
-      "end": 315.04,
-      "text": "What?",
-      "words": [
+        },
         {
           "start": 314.84,
           "end": 315.04,
@@ -9318,7 +8438,7 @@
       "id": 322,
       "start": 317.42,
       "end": 318.24,
-      "text": "I don’t rate him",
+      "text": "I don\u2019t rate him",
       "words": [
         {
           "start": 317.42,
@@ -9328,7 +8448,7 @@
         {
           "start": 317.64,
           "end": 317.88,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 317.88,
@@ -9347,8 +8467,8 @@
     {
       "id": 323,
       "start": 318.24,
-      "end": 319.7,
-      "text": "Hate me but I’m not fake like",
+      "end": 319.94,
+      "text": "Hate me but I\u2019m not fake like him",
       "words": [
         {
           "start": 318.24,
@@ -9368,7 +8488,7 @@
         {
           "start": 319.06,
           "end": 319.18,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 319.18,
@@ -9384,17 +8504,7 @@
           "start": 319.5,
           "end": 319.7,
           "word": " like"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 324,
-      "start": 319.7,
-      "end": 319.94,
-      "text": "him",
-      "words": [
+        },
         {
           "start": 319.7,
           "end": 319.94,
@@ -9407,8 +8517,8 @@
     {
       "id": 325,
       "start": 319.94,
-      "end": 321.4,
-      "text": "If I get started I’m buying off",
+      "end": 321.7,
+      "text": "If I get started I\u2019m buying off tings",
       "words": [
         {
           "start": 319.94,
@@ -9433,7 +8543,7 @@
         {
           "start": 320.86,
           "end": 321.08,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 321.08,
@@ -9444,17 +8554,7 @@
           "start": 321.2,
           "end": 321.4,
           "word": " off"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 326,
-      "start": 321.4,
-      "end": 321.7,
-      "text": "tings",
-      "words": [
+        },
         {
           "start": 321.4,
           "end": 321.7,
@@ -9467,8 +8567,8 @@
     {
       "id": 327,
       "start": 321.7,
-      "end": 322.82,
-      "text": "Brought a bright man but I will",
+      "end": 323.22,
+      "text": "Brought a bright man but I will get grim",
       "words": [
         {
           "start": 321.7,
@@ -9504,17 +8604,7 @@
           "start": 322.68,
           "end": 322.82,
           "word": " will"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 328,
-      "start": 322.82,
-      "end": 323.22,
-      "text": "get grim",
-      "words": [
+        },
         {
           "start": 322.82,
           "end": 323.02,
@@ -9530,26 +8620,16 @@
       "instrumental": null
     },
     {
-      "id": 329,
+      "id": 330,
       "start": 323.22,
-      "end": 323.7,
-      "text": "Look",
+      "end": 325.04,
+      "text": "Look But he\u2019s not beating him",
       "words": [
         {
           "start": 323.22,
           "end": 323.7,
           "word": " Look"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 330,
-      "start": 323.7,
-      "end": 325.04,
-      "text": "But he’s not beating him",
-      "words": [
+        },
         {
           "start": 323.7,
           "end": 324.24,
@@ -9558,7 +8638,7 @@
         {
           "start": 324.24,
           "end": 324.44,
-          "word": " he’s"
+          "word": " he\u2019s"
         },
         {
           "start": 324.44,
@@ -9582,8 +8662,8 @@
     {
       "id": 331,
       "start": 325.04,
-      "end": 326.44,
-      "text": "Wanna go hard but you really not",
+      "end": 327.62,
+      "text": "Wanna go hard but you really not grim But",
       "words": [
         {
           "start": 325.04,
@@ -9619,32 +8699,12 @@
           "start": 326.22,
           "end": 326.44,
           "word": " not"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 332,
-      "start": 326.44,
-      "end": 326.66,
-      "text": "grim",
-      "words": [
+        },
         {
           "start": 326.44,
           "end": 326.66,
           "word": " grim"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 333,
-      "start": 327.26,
-      "end": 327.62,
-      "text": "But",
-      "words": [
+        },
         {
           "start": 327.26,
           "end": 327.62,
@@ -9657,13 +8717,13 @@
     {
       "id": 334,
       "start": 328.34,
-      "end": 329.12,
-      "text": "What’s the ting then?",
+      "end": 329.6,
+      "text": "What\u2019s the ting then? I\u2019m here",
       "words": [
         {
           "start": 328.34,
           "end": 328.7,
-          "word": " What’s"
+          "word": " What\u2019s"
         },
         {
           "start": 328.7,
@@ -9679,21 +8739,11 @@
           "start": 328.98,
           "end": 329.12,
           "word": " then?"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 335,
-      "start": 329.22,
-      "end": 329.6,
-      "text": "I’m here",
-      "words": [
+        },
         {
           "start": 329.22,
           "end": 329.4,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 329.4,
@@ -9732,8 +8782,8 @@
     {
       "id": 337,
       "start": 330.1,
-      "end": 331.46,
-      "text": "Last time I saw this guy in",
+      "end": 331.88,
+      "text": "Last time I saw this guy in a Look",
       "words": [
         {
           "start": 330.1,
@@ -9769,32 +8819,12 @@
           "start": 331.28,
           "end": 331.46,
           "word": " in"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 338,
-      "start": 331.46,
-      "end": 331.48,
-      "text": "a",
-      "words": [
+        },
         {
           "start": 331.46,
           "end": 331.48,
           "word": " a"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 339,
-      "start": 331.48,
-      "end": 331.88,
-      "text": "Look",
-      "words": [
+        },
         {
           "start": 331.48,
           "end": 331.88,
@@ -9805,10 +8835,10 @@
       "instrumental": null
     },
     {
-      "id": 340,
+      "id": 341,
       "start": 331.88,
-      "end": 332.54,
-      "text": "Yes Lord",
+      "end": 333.38,
+      "text": "Yes Lord I\u2019ll come again with that",
       "words": [
         {
           "start": 331.88,
@@ -9819,21 +8849,11 @@
           "start": 332.38,
           "end": 332.54,
           "word": " Lord"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 341,
-      "start": 332.54,
-      "end": 333.38,
-      "text": "I’ll come again with that",
-      "words": [
+        },
         {
           "start": 332.54,
           "end": 332.8,
-          "word": " I’ll"
+          "word": " I\u2019ll"
         },
         {
           "start": 332.8,
@@ -9862,8 +8882,8 @@
     {
       "id": 342,
       "start": 333.38,
-      "end": 334.0,
-      "text": "What the hell you",
+      "end": 335.18,
+      "text": "What the hell you Man Yo",
       "words": [
         {
           "start": 333.38,
@@ -9884,32 +8904,12 @@
           "start": 333.76,
           "end": 334.0,
           "word": " you"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 343,
-      "start": 334.0,
-      "end": 334.26,
-      "text": "Man",
-      "words": [
+        },
         {
           "start": 334.0,
           "end": 334.26,
           "word": " Man"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 344,
-      "start": 334.82,
-      "end": 335.18,
-      "text": "Yo",
-      "words": [
+        },
         {
           "start": 334.82,
           "end": 335.18,
@@ -9922,8 +8922,8 @@
     {
       "id": 345,
       "start": 335.18,
-      "end": 335.82,
-      "text": "What the ting then?",
+      "end": 336.56,
+      "text": "What the ting then? Yeah Yo",
       "words": [
         {
           "start": 335.18,
@@ -9944,32 +8944,12 @@
           "start": 335.68,
           "end": 335.82,
           "word": " then?"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 346,
-      "start": 335.94,
-      "end": 336.1,
-      "text": "Yeah",
-      "words": [
+        },
         {
           "start": 335.94,
           "end": 336.1,
           "word": " Yeah"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 347,
-      "start": 336.1,
-      "end": 336.56,
-      "text": "Yo",
-      "words": [
+        },
         {
           "start": 336.1,
           "end": 336.56,
@@ -9982,8 +8962,8 @@
     {
       "id": 348,
       "start": 336.56,
-      "end": 337.96,
-      "text": "You wanna say him but you really",
+      "end": 338.38,
+      "text": "You wanna say him but you really no him",
       "words": [
         {
           "start": 336.56,
@@ -10019,17 +8999,7 @@
           "start": 337.76,
           "end": 337.96,
           "word": " really"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 349,
-      "start": 337.96,
-      "end": 338.38,
-      "text": "no him",
-      "words": [
+        },
         {
           "start": 337.96,
           "end": 338.12,
@@ -10047,8 +9017,8 @@
     {
       "id": 350,
       "start": 338.38,
-      "end": 339.76,
-      "text": "Wanna talk hard but you really no",
+      "end": 340.0,
+      "text": "Wanna talk hard but you really no grim",
       "words": [
         {
           "start": 338.38,
@@ -10084,17 +9054,7 @@
           "start": 339.6,
           "end": 339.76,
           "word": " no"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 351,
-      "start": 339.76,
-      "end": 340.0,
-      "text": "grim",
-      "words": [
+        },
         {
           "start": 339.76,
           "end": 340.0,
@@ -10107,8 +9067,8 @@
     {
       "id": 352,
       "start": 340.0,
-      "end": 341.58,
-      "text": "Outside your house I’ll pose for the",
+      "end": 341.74,
+      "text": "Outside your house I\u2019ll pose for the ting",
       "words": [
         {
           "start": 340.0,
@@ -10128,7 +9088,7 @@
         {
           "start": 340.96,
           "end": 341.18,
-          "word": " I’ll"
+          "word": " I\u2019ll"
         },
         {
           "start": 341.18,
@@ -10144,17 +9104,7 @@
           "start": 341.44,
           "end": 341.58,
           "word": " the"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 353,
-      "start": 341.58,
-      "end": 341.74,
-      "text": "ting",
-      "words": [
+        },
         {
           "start": 341.58,
           "end": 341.74,
@@ -10167,13 +9117,13 @@
     {
       "id": 354,
       "start": 341.74,
-      "end": 342.54,
-      "text": "What’s the ting then?",
+      "end": 343.0,
+      "text": "What\u2019s the ting then? I\u2019m here",
       "words": [
         {
           "start": 341.74,
           "end": 342.14,
-          "word": " What’s"
+          "word": " What\u2019s"
         },
         {
           "start": 342.14,
@@ -10189,21 +9139,11 @@
           "start": 342.4,
           "end": 342.54,
           "word": " then?"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 355,
-      "start": 342.64,
-      "end": 343.0,
-      "text": "I’m here",
-      "words": [
+        },
         {
           "start": 342.64,
           "end": 342.84,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 342.84,
@@ -10242,8 +9182,8 @@
     {
       "id": 357,
       "start": 343.52,
-      "end": 344.86,
-      "text": "Last time I saw this guy in",
+      "end": 345.1,
+      "text": "Last time I saw this guy in the dark",
       "words": [
         {
           "start": 343.52,
@@ -10279,17 +9219,7 @@
           "start": 344.7,
           "end": 344.86,
           "word": " in"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 358,
-      "start": 344.86,
-      "end": 345.1,
-      "text": "the dark",
-      "words": [
+        },
         {
           "start": 344.86,
           "end": 344.9,
@@ -10428,7 +9358,7 @@
       "id": 362,
       "start": 348.38,
       "end": 349.56,
-      "text": "He tried to call guys I’m",
+      "text": "He tried to call guys I\u2019m",
       "words": [
         {
           "start": 348.38,
@@ -10458,7 +9388,7 @@
         {
           "start": 349.3,
           "end": 349.56,
-          "word": " I’m"
+          "word": " I\u2019m"
         }
       ],
       "speaker": "Tempa T",
@@ -10467,8 +9397,8 @@
     {
       "id": 363,
       "start": 349.56,
-      "end": 350.16,
-      "text": "Boy of the ting",
+      "end": 351.9,
+      "text": "Boy of the ting Take care",
       "words": [
         {
           "start": 349.56,
@@ -10489,17 +9419,7 @@
           "start": 349.92,
           "end": 350.16,
           "word": " ting"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 364,
-      "start": 350.16,
-      "end": 351.9,
-      "text": "Take care",
-      "words": [
+        },
         {
           "start": 350.16,
           "end": 350.52,
@@ -10647,13 +9567,13 @@
     {
       "id": 369,
       "start": 355.22,
-      "end": 355.94,
-      "text": "What’s the ting then?",
+      "end": 356.4,
+      "text": "What\u2019s the ting then? I\u2019m here",
       "words": [
         {
           "start": 355.22,
           "end": 355.52,
-          "word": " What’s"
+          "word": " What\u2019s"
         },
         {
           "start": 355.52,
@@ -10669,21 +9589,11 @@
           "start": 355.8,
           "end": 355.94,
           "word": " then?"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 370,
-      "start": 356.06,
-      "end": 356.4,
-      "text": "I’m here",
-      "words": [
+        },
         {
           "start": 356.06,
           "end": 356.22,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 356.22,
@@ -10922,13 +9832,13 @@
     {
       "id": 379,
       "start": 361.86,
-      "end": 362.66,
-      "text": "What’s the ting then?",
+      "end": 363.12,
+      "text": "What\u2019s the ting then? I\u2019m here",
       "words": [
         {
           "start": 361.86,
           "end": 362.2,
-          "word": " What’s"
+          "word": " What\u2019s"
         },
         {
           "start": 362.2,
@@ -10944,21 +9854,11 @@
           "start": 362.5,
           "end": 362.66,
           "word": " then?"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 380,
-      "start": 362.78,
-      "end": 363.12,
-      "text": "I’m here",
-      "words": [
+        },
         {
           "start": 362.78,
           "end": 362.94,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 362.94,
@@ -10972,13 +9872,13 @@
     {
       "id": 381,
       "start": 363.12,
-      "end": 363.56,
-      "text": "It’s a ting,",
+      "end": 363.94,
+      "text": "It\u2019s a ting, boy,",
       "words": [
         {
           "start": 363.12,
           "end": 363.34,
-          "word": " It’s"
+          "word": " It\u2019s"
         },
         {
           "start": 363.34,
@@ -10989,17 +9889,7 @@
           "start": 363.34,
           "end": 363.56,
           "word": " ting,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 382,
-      "start": 363.66,
-      "end": 363.94,
-      "text": "boy,",
-      "words": [
+        },
         {
           "start": 363.66,
           "end": 363.94,
@@ -11012,13 +9902,13 @@
     {
       "id": 383,
       "start": 364.06,
-      "end": 365.24,
-      "text": "don’t let me boy off the ting,",
+      "end": 365.74,
+      "text": "don\u2019t let me boy off the ting, boy",
       "words": [
         {
           "start": 364.06,
           "end": 364.4,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 364.4,
@@ -11049,17 +9939,7 @@
           "start": 365.06,
           "end": 365.24,
           "word": " ting,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 384,
-      "start": 365.32,
-      "end": 365.74,
-      "text": "boy",
-      "words": [
+        },
         {
           "start": 365.32,
           "end": 365.74,
@@ -11072,13 +9952,13 @@
     {
       "id": 385,
       "start": 365.74,
-      "end": 366.98,
-      "text": "Don’t let me boy off the ting,",
+      "end": 367.34,
+      "text": "Don\u2019t let me boy off the ting, boy",
       "words": [
         {
           "start": 365.74,
           "end": 366.08,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 366.08,
@@ -11109,17 +9989,7 @@
           "start": 366.72,
           "end": 366.98,
           "word": " ting,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 386,
-      "start": 367.0,
-      "end": 367.34,
-      "text": "boy",
-      "words": [
+        },
         {
           "start": 367.0,
           "end": 367.34,
@@ -11133,12 +10003,12 @@
       "id": 387,
       "start": 367.34,
       "end": 368.34,
-      "text": "Don’t let me boy off,",
+      "text": "Don\u2019t let me boy off,",
       "words": [
         {
           "start": 367.34,
           "end": 367.76,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 367.76,
@@ -11212,8 +10082,8 @@
     {
       "id": 389,
       "start": 369.62,
-      "end": 370.26,
-      "text": "boy off the ting",
+      "end": 370.86,
+      "text": "boy off the ting Like boy,",
       "words": [
         {
           "start": 369.62,
@@ -11234,17 +10104,7 @@
           "start": 370.1,
           "end": 370.26,
           "word": " ting"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 390,
-      "start": 370.26,
-      "end": 370.86,
-      "text": "Like boy,",
-      "words": [
+        },
         {
           "start": 370.26,
           "end": 370.44,
@@ -11262,8 +10122,8 @@
     {
       "id": 391,
       "start": 370.96,
-      "end": 371.98,
-      "text": "then lick off the ting,",
+      "end": 372.36,
+      "text": "then lick off the ting, boy",
       "words": [
         {
           "start": 370.96,
@@ -11289,17 +10149,7 @@
           "start": 371.78,
           "end": 371.98,
           "word": " ting,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 392,
-      "start": 372.1,
-      "end": 372.36,
-      "text": "boy",
-      "words": [
+        },
         {
           "start": 372.1,
           "end": 372.36,
@@ -11312,13 +10162,13 @@
     {
       "id": 393,
       "start": 372.36,
-      "end": 373.68,
-      "text": "Don’t let me boy off the ting,",
+      "end": 374.02,
+      "text": "Don\u2019t let me boy off the ting, boy",
       "words": [
         {
           "start": 372.36,
           "end": 372.8,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 372.8,
@@ -11349,17 +10199,7 @@
           "start": 373.44,
           "end": 373.68,
           "word": " ting,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 394,
-      "start": 373.76,
-      "end": 374.02,
-      "text": "boy",
-      "words": [
+        },
         {
           "start": 373.76,
           "end": 374.02,
@@ -11485,26 +10325,16 @@
       "instrumental": null
     },
     {
-      "id": 398,
+      "id": 399,
       "start": 377.0,
-      "end": 377.4,
-      "text": "Yo,",
+      "end": 378.62,
+      "text": "Yo, I said danger, danger",
       "words": [
         {
           "start": 377.0,
           "end": 377.4,
           "word": " Yo,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 399,
-      "start": 377.54,
-      "end": 378.26,
-      "text": "I said danger,",
-      "words": [
+        },
         {
           "start": 377.54,
           "end": 377.76,
@@ -11519,17 +10349,7 @@
           "start": 377.92,
           "end": 378.26,
           "word": " danger,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 400,
-      "start": 378.38,
-      "end": 378.62,
-      "text": "danger",
-      "words": [
+        },
         {
           "start": 378.38,
           "end": 378.62,
@@ -11543,7 +10363,7 @@
       "id": 401,
       "start": 378.62,
       "end": 380.64,
-      "text": "Somebody tell these babies there’s no space",
+      "text": "Somebody tell these babies there\u2019s no space",
       "words": [
         {
           "start": 378.62,
@@ -11568,7 +10388,7 @@
         {
           "start": 379.94,
           "end": 380.3,
-          "word": " there’s"
+          "word": " there\u2019s"
         },
         {
           "start": 380.3,
@@ -11637,8 +10457,8 @@
     {
       "id": 404,
       "start": 382.24,
-      "end": 383.14,
-      "text": "I send for the head top,",
+      "end": 383.88,
+      "text": "I send for the head top, rearrange up",
       "words": [
         {
           "start": 382.24,
@@ -11669,17 +10489,7 @@
           "start": 382.98,
           "end": 383.14,
           "word": " top,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 405,
-      "start": 383.2,
-      "end": 383.88,
-      "text": "rearrange up",
-      "words": [
+        },
         {
           "start": 383.2,
           "end": 383.42,
@@ -11738,12 +10548,12 @@
       "id": 407,
       "start": 385.04,
       "end": 387.04,
-      "text": "I’m JME multiplied by Maxwell Ranger",
+      "text": "I\u2019m JME multiplied by Maxwell Ranger",
       "words": [
         {
           "start": 385.04,
           "end": 385.3,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 385.3,
@@ -11778,12 +10588,12 @@
       "id": 408,
       "start": 387.04,
       "end": 387.92,
-      "text": "I’m way too serious,",
+      "text": "I\u2019m way too serious,",
       "words": [
         {
           "start": 387.04,
           "end": 387.26,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 387.26,
@@ -11808,7 +10618,7 @@
       "id": 409,
       "start": 388.06,
       "end": 389.34,
-      "text": "if you don’t wanna get taken away",
+      "text": "if you don\u2019t wanna get taken away",
       "words": [
         {
           "start": 388.06,
@@ -11823,7 +10633,7 @@
         {
           "start": 388.36,
           "end": 388.44,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 388.44,
@@ -11853,12 +10663,12 @@
       "id": 410,
       "start": 389.34,
       "end": 390.3,
-      "text": "Don’t talk to the stranger,",
+      "text": "Don\u2019t talk to the stranger,",
       "words": [
         {
           "start": 389.34,
           "end": 389.68,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 389.68,
@@ -11888,12 +10698,12 @@
       "id": 411,
       "start": 390.54,
       "end": 391.16,
-      "text": "I’m in the dark",
+      "text": "I\u2019m in the dark",
       "words": [
         {
           "start": 390.54,
           "end": 390.86,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 390.86,
@@ -11918,7 +10728,7 @@
       "id": 412,
       "start": 391.16,
       "end": 392.1,
-      "text": "Trying to see who’s the strongest",
+      "text": "Trying to see who\u2019s the strongest",
       "words": [
         {
           "start": 391.16,
@@ -11938,7 +10748,7 @@
         {
           "start": 391.52,
           "end": 391.78,
-          "word": " who’s"
+          "word": " who\u2019s"
         },
         {
           "start": 391.78,
@@ -11958,12 +10768,12 @@
       "id": 413,
       "start": 392.1,
       "end": 392.84,
-      "text": "You’re in the dark,",
+      "text": "You\u2019re in the dark,",
       "words": [
         {
           "start": 392.1,
           "end": 392.5,
-          "word": " You’re"
+          "word": " You\u2019re"
         },
         {
           "start": 392.5,
@@ -12057,8 +10867,8 @@
     {
       "id": 416,
       "start": 394.62,
-      "end": 395.96,
-      "text": "I don’t wanna play no screw face",
+      "end": 396.18,
+      "text": "I don\u2019t wanna play no screw face game,",
       "words": [
         {
           "start": 394.62,
@@ -12068,7 +10878,7 @@
         {
           "start": 394.98,
           "end": 395.12,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 395.12,
@@ -12094,17 +10904,7 @@
           "start": 395.72,
           "end": 395.96,
           "word": " face"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 417,
-      "start": 395.96,
-      "end": 396.18,
-      "text": "game,",
-      "words": [
+        },
         {
           "start": 395.96,
           "end": 396.18,
@@ -12115,10 +10915,10 @@
       "instrumental": null
     },
     {
-      "id": 418,
+      "id": 419,
       "start": 396.26,
-      "end": 396.72,
-      "text": "but cuzzy,",
+      "end": 397.32,
+      "text": "but cuzzy, I\u2019m on this",
       "words": [
         {
           "start": 396.26,
@@ -12129,21 +10929,11 @@
           "start": 396.38,
           "end": 396.72,
           "word": " cuzzy,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 419,
-      "start": 396.72,
-      "end": 397.32,
-      "text": "I’m on this",
-      "words": [
+        },
         {
           "start": 396.72,
           "end": 396.86,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 396.86,
@@ -12207,8 +10997,8 @@
     {
       "id": 421,
       "start": 399.08,
-      "end": 400.4,
-      "text": "You need to jam like a wee",
+      "end": 400.62,
+      "text": "You need to jam like a wee boy",
       "words": [
         {
           "start": 399.08,
@@ -12244,17 +11034,7 @@
           "start": 400.24,
           "end": 400.4,
           "word": " wee"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 422,
-      "start": 400.4,
-      "end": 400.62,
-      "text": "boy",
-      "words": [
+        },
         {
           "start": 400.4,
           "end": 400.62,
@@ -12267,8 +11047,8 @@
     {
       "id": 423,
       "start": 400.62,
-      "end": 401.66,
-      "text": "You will get left laying on the",
+      "end": 402.24,
+      "text": "You will get left laying on the concrete floor",
       "words": [
         {
           "start": 400.62,
@@ -12304,17 +11084,7 @@
           "start": 401.56,
           "end": 401.66,
           "word": " the"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 424,
-      "start": 401.66,
-      "end": 402.24,
-      "text": "concrete floor",
-      "words": [
+        },
         {
           "start": 401.66,
           "end": 401.98,
@@ -12332,8 +11102,8 @@
     {
       "id": 425,
       "start": 402.24,
-      "end": 403.1,
-      "text": "All you be hearing is,",
+      "end": 404.0,
+      "text": "All you be hearing is, neeno, neeno",
       "words": [
         {
           "start": 402.24,
@@ -12359,32 +11129,12 @@
           "start": 402.82,
           "end": 403.1,
           "word": " is,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 426,
-      "start": 403.16,
-      "end": 403.56,
-      "text": "neeno,",
-      "words": [
+        },
         {
           "start": 403.16,
           "end": 403.56,
           "word": " neeno,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 427,
-      "start": 403.56,
-      "end": 404.0,
-      "text": "neeno",
-      "words": [
+        },
         {
           "start": 403.56,
           "end": 404.0,
@@ -12397,8 +11147,8 @@
     {
       "id": 428,
       "start": 404.0,
-      "end": 404.62,
-      "text": "Look in my boat,",
+      "end": 404.94,
+      "text": "Look in my boat, fine",
       "words": [
         {
           "start": 404.0,
@@ -12419,17 +11169,7 @@
           "start": 404.38,
           "end": 404.62,
           "word": " boat,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 429,
-      "start": 404.68,
-      "end": 404.94,
-      "text": "fine",
-      "words": [
+        },
         {
           "start": 404.68,
           "end": 404.94,
@@ -12443,12 +11183,12 @@
       "id": 430,
       "start": 404.94,
       "end": 406.7,
-      "text": "You’re the reason I wrote this rhyme",
+      "text": "You\u2019re the reason I wrote this rhyme",
       "words": [
         {
           "start": 404.94,
           "end": 405.42,
-          "word": " You’re"
+          "word": " You\u2019re"
         },
         {
           "start": 405.42,
@@ -12485,41 +11225,21 @@
       "instrumental": null
     },
     {
-      "id": 431,
+      "id": 433,
       "start": 406.7,
-      "end": 407.08,
-      "text": "Yo,",
+      "end": 407.86,
+      "text": "Yo, man, I baited, man,",
       "words": [
         {
           "start": 406.7,
           "end": 407.08,
           "word": " Yo,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 432,
-      "start": 407.12,
-      "end": 407.26,
-      "text": "man,",
-      "words": [
+        },
         {
           "start": 407.12,
           "end": 407.26,
           "word": " man,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 433,
-      "start": 407.28,
-      "end": 407.72,
-      "text": "I baited,",
-      "words": [
+        },
         {
           "start": 407.28,
           "end": 407.4,
@@ -12529,17 +11249,7 @@
           "start": 407.4,
           "end": 407.72,
           "word": " baited,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 434,
-      "start": 407.72,
-      "end": 407.86,
-      "text": "man,",
-      "words": [
+        },
         {
           "start": 407.72,
           "end": 407.86,
@@ -12552,8 +11262,8 @@
     {
       "id": 435,
       "start": 407.96,
-      "end": 408.36,
-      "text": "I bad man",
+      "end": 408.56,
+      "text": "I bad man Man,",
       "words": [
         {
           "start": 407.96,
@@ -12569,17 +11279,7 @@
           "start": 408.16,
           "end": 408.36,
           "word": " man"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 436,
-      "start": 408.36,
-      "end": 408.56,
-      "text": "Man,",
-      "words": [
+        },
         {
           "start": 408.36,
           "end": 408.56,
@@ -12592,8 +11292,8 @@
     {
       "id": 437,
       "start": 408.58,
-      "end": 409.64,
-      "text": "I ain’t seen a five pound note",
+      "end": 410.06,
+      "text": "I ain\u2019t seen a five pound note in time",
       "words": [
         {
           "start": 408.58,
@@ -12603,7 +11303,7 @@
         {
           "start": 408.66,
           "end": 408.84,
-          "word": " ain’t"
+          "word": " ain\u2019t"
         },
         {
           "start": 408.84,
@@ -12629,17 +11329,7 @@
           "start": 409.44,
           "end": 409.64,
           "word": " note"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 438,
-      "start": 409.64,
-      "end": 410.06,
-      "text": "in time",
-      "words": [
+        },
         {
           "start": 409.64,
           "end": 409.8,
@@ -12655,30 +11345,20 @@
       "instrumental": null
     },
     {
-      "id": 439,
+      "id": 440,
       "start": 410.06,
-      "end": 410.46,
-      "text": "Yo,",
+      "end": 412.28,
+      "text": "Yo, can\u2019t dis a friend of mine Trust me,",
       "words": [
         {
           "start": 410.06,
           "end": 410.46,
           "word": " Yo,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 440,
-      "start": 410.52,
-      "end": 411.7,
-      "text": "can’t dis a friend of mine",
-      "words": [
+        },
         {
           "start": 410.52,
           "end": 410.92,
-          "word": " can’t"
+          "word": " can\u2019t"
         },
         {
           "start": 410.92,
@@ -12704,17 +11384,7 @@
           "start": 411.46,
           "end": 411.7,
           "word": " mine"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 441,
-      "start": 411.7,
-      "end": 412.28,
-      "text": "Trust me,",
-      "words": [
+        },
         {
           "start": 411.7,
           "end": 412.06,
@@ -12733,7 +11403,7 @@
       "id": 442,
       "start": 412.34,
       "end": 413.38,
-      "text": "you don’t wanna cross this line",
+      "text": "you don\u2019t wanna cross this line",
       "words": [
         {
           "start": 412.34,
@@ -12743,7 +11413,7 @@
         {
           "start": 412.44,
           "end": 412.62,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 412.62,
@@ -12773,12 +11443,12 @@
       "id": 443,
       "start": 413.38,
       "end": 414.7,
-      "text": "Don’t think you can stand in the",
+      "text": "Don\u2019t think you can stand in the",
       "words": [
         {
           "start": 413.38,
           "end": 413.84,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 413.84,
@@ -12847,13 +11517,13 @@
     {
       "id": 445,
       "start": 415.56,
-      "end": 416.76,
-      "text": "I’d live in next man’s wine",
+      "end": 417.14,
+      "text": "I\u2019d live in next man\u2019s wine Snap,",
       "words": [
         {
           "start": 415.56,
           "end": 415.92,
-          "word": " I’d"
+          "word": " I\u2019d"
         },
         {
           "start": 415.92,
@@ -12873,23 +11543,13 @@
         {
           "start": 416.3,
           "end": 416.6,
-          "word": " man’s"
+          "word": " man\u2019s"
         },
         {
           "start": 416.6,
           "end": 416.76,
           "word": " wine"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 446,
-      "start": 416.76,
-      "end": 417.14,
-      "text": "Snap,",
-      "words": [
+        },
         {
           "start": 416.76,
           "end": 417.14,
@@ -12903,7 +11563,7 @@
       "id": 447,
       "start": 417.38,
       "end": 418.46,
-      "text": "do you think I’m dumb?",
+      "text": "do you think I\u2019m dumb?",
       "words": [
         {
           "start": 417.38,
@@ -12923,7 +11583,7 @@
         {
           "start": 418.04,
           "end": 418.28,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 418.28,
@@ -12937,8 +11597,8 @@
     {
       "id": 448,
       "start": 418.56,
-      "end": 419.32,
-      "text": "Try to boy me,",
+      "end": 419.48,
+      "text": "Try to boy me, no,",
       "words": [
         {
           "start": 418.56,
@@ -12959,17 +11619,7 @@
           "start": 419.16,
           "end": 419.32,
           "word": " me,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 449,
-      "start": 419.34,
-      "end": 419.48,
-      "text": "no,",
-      "words": [
+        },
         {
           "start": 419.34,
           "end": 419.48,
@@ -12982,8 +11632,8 @@
     {
       "id": 450,
       "start": 419.5,
-      "end": 420.08,
-      "text": "that can’t run",
+      "end": 420.96,
+      "text": "that can\u2019t run Yo, you\u2019re lucky",
       "words": [
         {
           "start": 419.5,
@@ -12993,42 +11643,22 @@
         {
           "start": 419.62,
           "end": 419.96,
-          "word": " can’t"
+          "word": " can\u2019t"
         },
         {
           "start": 419.96,
           "end": 420.08,
           "word": " run"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 451,
-      "start": 420.08,
-      "end": 420.54,
-      "text": "Yo,",
-      "words": [
+        },
         {
           "start": 420.08,
           "end": 420.54,
           "word": " Yo,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 452,
-      "start": 420.58,
-      "end": 420.96,
-      "text": "you’re lucky",
-      "words": [
+        },
         {
           "start": 420.58,
           "end": 420.84,
-          "word": " you’re"
+          "word": " you\u2019re"
         },
         {
           "start": 420.84,
@@ -13122,8 +11752,8 @@
     {
       "id": 455,
       "start": 423.46,
-      "end": 424.56,
-      "text": "Cause you get your name in your",
+      "end": 425.22,
+      "text": "Cause you get your name in your nightcare dunks",
       "words": [
         {
           "start": 423.46,
@@ -13159,17 +11789,7 @@
           "start": 424.46,
           "end": 424.56,
           "word": " your"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 456,
-      "start": 424.56,
-      "end": 425.22,
-      "text": "nightcare dunks",
-      "words": [
+        },
         {
           "start": 424.56,
           "end": 424.9,
@@ -13257,8 +11877,8 @@
     {
       "id": 459,
       "start": 426.84,
-      "end": 427.92,
-      "text": "You could have your name in your",
+      "end": 428.6,
+      "text": "You could have your name in your Reebok pumps",
       "words": [
         {
           "start": 426.84,
@@ -13294,17 +11914,7 @@
           "start": 427.82,
           "end": 427.92,
           "word": " your"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 460,
-      "start": 427.92,
-      "end": 428.6,
-      "text": "Reebok pumps",
-      "words": [
+        },
         {
           "start": 427.92,
           "end": 428.22,
@@ -13322,13 +11932,13 @@
     {
       "id": 461,
       "start": 428.6,
-      "end": 429.86,
-      "text": "Don’t think you could ever dis my",
+      "end": 430.44,
+      "text": "Don\u2019t think you could ever dis my rock Yo,",
       "words": [
         {
           "start": 428.6,
           "end": 428.94,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 428.94,
@@ -13359,32 +11969,12 @@
           "start": 429.68,
           "end": 429.86,
           "word": " my"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 462,
-      "start": 429.86,
-      "end": 430.18,
-      "text": "rock",
-      "words": [
+        },
         {
           "start": 429.86,
           "end": 430.18,
           "word": " rock"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 463,
-      "start": 430.18,
-      "end": 430.44,
-      "text": "Yo,",
-      "words": [
+        },
         {
           "start": 430.18,
           "end": 430.44,
@@ -13395,41 +11985,21 @@
       "instrumental": null
     },
     {
-      "id": 464,
+      "id": 466,
       "start": 430.44,
-      "end": 430.72,
-      "text": "yo,",
+      "end": 431.24,
+      "text": "yo, yo, yo",
       "words": [
         {
           "start": 430.44,
           "end": 430.72,
           "word": " yo,"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 465,
-      "start": 430.72,
-      "end": 430.84,
-      "text": "yo,",
-      "words": [
+        },
         {
           "start": 430.72,
           "end": 430.84,
           "word": " yo,"
-        }
-      ],
-      "speaker": "Jme",
-      "instrumental": null
-    },
-    {
-      "id": 466,
-      "start": 430.92,
-      "end": 431.24,
-      "text": "yo",
-      "words": [
+        },
         {
           "start": 430.92,
           "end": 431.24,
@@ -13443,7 +12013,7 @@
       "id": 467,
       "start": 431.24,
       "end": 432.96,
-      "text": "You might see me there on Logan’s",
+      "text": "You might see me there on Logan\u2019s",
       "words": [
         {
           "start": 431.24,
@@ -13478,7 +12048,7 @@
         {
           "start": 432.46,
           "end": 432.96,
-          "word": " Logan’s"
+          "word": " Logan\u2019s"
         }
       ],
       "speaker": "Jme",
@@ -13487,8 +12057,8 @@
     {
       "id": 468,
       "start": 432.96,
-      "end": 433.96,
-      "text": "You might see me there",
+      "end": 434.66,
+      "text": "You might see me there Showering,",
       "words": [
         {
           "start": 432.96,
@@ -13514,17 +12084,7 @@
           "start": 433.68,
           "end": 433.96,
           "word": " there"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 469,
-      "start": 433.96,
-      "end": 434.66,
-      "text": "Showering,",
-      "words": [
+        },
         {
           "start": 433.96,
           "end": 434.66,
@@ -13577,13 +12137,13 @@
     {
       "id": 471,
       "start": 435.66,
-      "end": 437.08,
-      "text": "It’s gonna be mine all night this",
+      "end": 437.34,
+      "text": "It\u2019s gonna be mine all night this year",
       "words": [
         {
           "start": 435.66,
           "end": 435.92,
-          "word": " It’s"
+          "word": " It\u2019s"
         },
         {
           "start": 435.92,
@@ -13614,17 +12174,7 @@
           "start": 436.9,
           "end": 437.08,
           "word": " this"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 472,
-      "start": 437.08,
-      "end": 437.34,
-      "text": "year",
-      "words": [
+        },
         {
           "start": 437.08,
           "end": 437.34,
@@ -13635,10 +12185,10 @@
       "instrumental": null
     },
     {
-      "id": 473,
+      "id": 474,
       "start": 437.34,
-      "end": 438.14,
-      "text": "Staying fat,",
+      "end": 438.98,
+      "text": "Staying fat, claiming that",
       "words": [
         {
           "start": 437.34,
@@ -13649,17 +12199,7 @@
           "start": 437.92,
           "end": 438.14,
           "word": " fat,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 474,
-      "start": 438.28,
-      "end": 438.98,
-      "text": "claiming that",
-      "words": [
+        },
         {
           "start": 438.28,
           "end": 438.72,
@@ -13678,12 +12218,12 @@
       "id": 475,
       "start": 438.98,
       "end": 440.68,
-      "text": "I’m gonna be gon’ clear this year",
+      "text": "I\u2019m gonna be gon\u2019 clear this year",
       "words": [
         {
           "start": 438.98,
           "end": 439.44,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 439.44,
@@ -13698,7 +12238,7 @@
         {
           "start": 439.78,
           "end": 440.0,
-          "word": " gon’"
+          "word": " gon\u2019"
         },
         {
           "start": 440.04,
@@ -13723,12 +12263,12 @@
       "id": 476,
       "start": 440.68,
       "end": 442.36,
-      "text": "There’s no point of staring here",
+      "text": "There\u2019s no point of staring here",
       "words": [
         {
           "start": 440.68,
           "end": 441.2,
-          "word": " There’s"
+          "word": " There\u2019s"
         },
         {
           "start": 441.2,
@@ -13762,8 +12302,8 @@
     {
       "id": 477,
       "start": 442.36,
-      "end": 443.5,
-      "text": "You won’t be high cause I’m shifting",
+      "end": 444.08,
+      "text": "You won\u2019t be high cause I\u2019m shifting fifth there",
       "words": [
         {
           "start": 442.36,
@@ -13773,7 +12313,7 @@
         {
           "start": 442.52,
           "end": 442.7,
-          "word": " won’t"
+          "word": " won\u2019t"
         },
         {
           "start": 442.7,
@@ -13793,23 +12333,13 @@
         {
           "start": 443.12,
           "end": 443.28,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 443.28,
           "end": 443.5,
           "word": " shifting"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 478,
-      "start": 443.5,
-      "end": 444.08,
-      "text": "fifth there",
-      "words": [
+        },
         {
           "start": 443.5,
           "end": 443.82,
@@ -13825,10 +12355,10 @@
       "instrumental": null
     },
     {
-      "id": 479,
+      "id": 480,
       "start": 444.08,
-      "end": 444.96,
-      "text": "Caring hair,",
+      "end": 445.78,
+      "text": "Caring hair, clearing hair",
       "words": [
         {
           "start": 444.08,
@@ -13839,17 +12369,7 @@
           "start": 444.58,
           "end": 444.96,
           "word": " hair,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 480,
-      "start": 445.06,
-      "end": 445.78,
-      "text": "clearing hair",
-      "words": [
+        },
         {
           "start": 445.06,
           "end": 445.42,
@@ -13867,13 +12387,13 @@
     {
       "id": 481,
       "start": 445.78,
-      "end": 446.68,
-      "text": "You’re on point for music,",
+      "end": 447.42,
+      "text": "You\u2019re on point for music, staring hair",
       "words": [
         {
           "start": 445.78,
           "end": 446.0,
-          "word": " You’re"
+          "word": " You\u2019re"
         },
         {
           "start": 446.0,
@@ -13894,17 +12414,7 @@
           "start": 446.38,
           "end": 446.68,
           "word": " music,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 482,
-      "start": 446.76,
-      "end": 447.42,
-      "text": "staring hair",
-      "words": [
+        },
         {
           "start": 446.76,
           "end": 447.02,
@@ -13922,13 +12432,13 @@
     {
       "id": 483,
       "start": 447.42,
-      "end": 449.04,
-      "text": "Don’t wanna see me pacing here",
+      "end": 449.76,
+      "text": "Don\u2019t wanna see me pacing here Great charisma,",
       "words": [
         {
           "start": 447.42,
           "end": 447.88,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 447.88,
@@ -13954,17 +12464,7 @@
           "start": 448.78,
           "end": 449.04,
           "word": " here"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 484,
-      "start": 449.04,
-      "end": 449.76,
-      "text": "Great charisma,",
-      "words": [
+        },
         {
           "start": 449.04,
           "end": 449.46,
@@ -13982,8 +12482,8 @@
     {
       "id": 485,
       "start": 449.84,
-      "end": 450.72,
-      "text": "you can’t take my fare",
+      "end": 451.18,
+      "text": "you can\u2019t take my fare Look,",
       "words": [
         {
           "start": 449.84,
@@ -13993,7 +12493,7 @@
         {
           "start": 449.96,
           "end": 450.16,
-          "word": " can’t"
+          "word": " can\u2019t"
         },
         {
           "start": 450.16,
@@ -14009,17 +12509,7 @@
           "start": 450.5,
           "end": 450.72,
           "word": " fare"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 486,
-      "start": 450.72,
-      "end": 451.18,
-      "text": "Look,",
-      "words": [
+        },
         {
           "start": 450.72,
           "end": 451.18,
@@ -14033,12 +12523,12 @@
       "id": 487,
       "start": 451.28,
       "end": 452.42,
-      "text": "I’m that grizzly bear",
+      "text": "I\u2019m that grizzly bear",
       "words": [
         {
           "start": 451.28,
           "end": 451.64,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 451.64,
@@ -14062,8 +12552,8 @@
     {
       "id": 488,
       "start": 452.42,
-      "end": 453.14,
-      "text": "I take competition,",
+      "end": 454.2,
+      "text": "I take competition, I impairs",
       "words": [
         {
           "start": 452.42,
@@ -14079,17 +12569,7 @@
           "start": 452.76,
           "end": 453.14,
           "word": " competition,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 489,
-      "start": 453.42,
-      "end": 454.2,
-      "text": "I impairs",
-      "words": [
+        },
         {
           "start": 453.42,
           "end": 453.66,
@@ -14108,12 +12588,12 @@
       "id": 490,
       "start": 454.2,
       "end": 455.76,
-      "text": "There’s no point of passing here",
+      "text": "There\u2019s no point of passing here",
       "words": [
         {
           "start": 454.2,
           "end": 454.66,
-          "word": " There’s"
+          "word": " There\u2019s"
         },
         {
           "start": 454.66,
@@ -14147,8 +12627,8 @@
     {
       "id": 491,
       "start": 455.76,
-      "end": 456.88,
-      "text": "I look in your eyes and you’re",
+      "end": 457.48,
+      "text": "I look in your eyes and you\u2019re busting fair",
       "words": [
         {
           "start": 455.76,
@@ -14183,18 +12663,8 @@
         {
           "start": 456.7,
           "end": 456.88,
-          "word": " you’re"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 492,
-      "start": 456.88,
-      "end": 457.48,
-      "text": "busting fair",
-      "words": [
+          "word": " you\u2019re"
+        },
         {
           "start": 456.88,
           "end": 457.18,
@@ -14210,10 +12680,10 @@
       "instrumental": null
     },
     {
-      "id": 493,
+      "id": 494,
       "start": 457.48,
-      "end": 458.36,
-      "text": "Caring hair,",
+      "end": 459.18,
+      "text": "Caring hair, clearing hair",
       "words": [
         {
           "start": 457.48,
@@ -14224,17 +12694,7 @@
           "start": 458.02,
           "end": 458.36,
           "word": " hair,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 494,
-      "start": 458.5,
-      "end": 459.18,
-      "text": "clearing hair",
-      "words": [
+        },
         {
           "start": 458.5,
           "end": 458.9,
@@ -14253,7 +12713,7 @@
       "id": 495,
       "start": 459.18,
       "end": 460.84,
-      "text": "Everyone knows I’m caring hair",
+      "text": "Everyone knows I\u2019m caring hair",
       "words": [
         {
           "start": 459.18,
@@ -14268,7 +12728,7 @@
         {
           "start": 460.04,
           "end": 460.3,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 460.3,
@@ -14287,13 +12747,13 @@
     {
       "id": 496,
       "start": 460.84,
-      "end": 462.34,
-      "text": "Don’t wanna see a mixtape in the",
+      "end": 462.52,
+      "text": "Don\u2019t wanna see a mixtape in the shop",
       "words": [
         {
           "start": 460.84,
           "end": 461.34,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 461.34,
@@ -14324,17 +12784,7 @@
           "start": 462.26,
           "end": 462.34,
           "word": " the"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 497,
-      "start": 462.34,
-      "end": 462.52,
-      "text": "shop",
-      "words": [
+        },
         {
           "start": 462.34,
           "end": 462.52,
@@ -14345,10 +12795,10 @@
       "instrumental": null
     },
     {
-      "id": 498,
+      "id": 499,
       "start": 462.52,
-      "end": 463.18,
-      "text": "Trust me,",
+      "end": 464.74,
+      "text": "Trust me, I\u2019ll be caring there Snap,",
       "words": [
         {
           "start": 462.52,
@@ -14359,21 +12809,11 @@
           "start": 462.94,
           "end": 463.18,
           "word": " me,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 499,
-      "start": 463.26,
-      "end": 464.24,
-      "text": "I’ll be caring there",
-      "words": [
+        },
         {
           "start": 463.26,
           "end": 463.54,
-          "word": " I’ll"
+          "word": " I\u2019ll"
         },
         {
           "start": 463.54,
@@ -14389,17 +12829,7 @@
           "start": 463.92,
           "end": 464.24,
           "word": " there"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 500,
-      "start": 464.24,
-      "end": 464.74,
-      "text": "Snap,",
-      "words": [
+        },
         {
           "start": 464.24,
           "end": 464.74,
@@ -14412,8 +12842,8 @@
     {
       "id": 501,
       "start": 464.78,
-      "end": 465.52,
-      "text": "my face in the mix,",
+      "end": 466.42,
+      "text": "my face in the mix, CD free Chronic,",
       "words": [
         {
           "start": 464.78,
@@ -14439,17 +12869,7 @@
           "start": 465.34,
           "end": 465.52,
           "word": " mix,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 502,
-      "start": 465.54,
-      "end": 466.02,
-      "text": "CD free",
-      "words": [
+        },
         {
           "start": 465.54,
           "end": 465.72,
@@ -14459,17 +12879,7 @@
           "start": 465.72,
           "end": 466.02,
           "word": " free"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 503,
-      "start": 466.02,
-      "end": 466.42,
-      "text": "Chronic,",
-      "words": [
+        },
         {
           "start": 466.02,
           "end": 466.42,
@@ -14482,8 +12892,8 @@
     {
       "id": 504,
       "start": 466.42,
-      "end": 467.18,
-      "text": "holding it down,",
+      "end": 468.1,
+      "text": "holding it down, I swear Furthermore,",
       "words": [
         {
           "start": 466.42,
@@ -14499,17 +12909,7 @@
           "start": 466.98,
           "end": 467.18,
           "word": " down,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 505,
-      "start": 467.24,
-      "end": 467.56,
-      "text": "I swear",
-      "words": [
+        },
         {
           "start": 467.24,
           "end": 467.34,
@@ -14519,17 +12919,7 @@
           "start": 467.34,
           "end": 467.56,
           "word": " swear"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 506,
-      "start": 467.56,
-      "end": 468.1,
-      "text": "Furthermore,",
-      "words": [
+        },
         {
           "start": 467.56,
           "end": 468.1,
@@ -14543,12 +12933,12 @@
       "id": 507,
       "start": 468.36,
       "end": 469.2,
-      "text": "I’m about this year",
+      "text": "I\u2019m about this year",
       "words": [
         {
           "start": 468.36,
           "end": 468.62,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 468.62,
@@ -14602,13 +12992,13 @@
     {
       "id": 509,
       "start": 469.92,
-      "end": 470.96,
-      "text": "don’t settle down this year",
+      "end": 471.3,
+      "text": "don\u2019t settle down this year Yo,",
       "words": [
         {
           "start": 469.92,
           "end": 470.1,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 470.1,
@@ -14629,17 +13019,7 @@
           "start": 470.74,
           "end": 470.96,
           "word": " year"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 510,
-      "start": 470.96,
-      "end": 471.3,
-      "text": "Yo,",
-      "words": [
+        },
         {
           "start": 470.96,
           "end": 471.3,
@@ -14650,30 +13030,20 @@
       "instrumental": null
     },
     {
-      "id": 511,
+      "id": 512,
       "start": 471.3,
-      "end": 471.76,
-      "text": "yo,",
+      "end": 472.64,
+      "text": "yo, it\u2019s mental",
       "words": [
         {
           "start": 471.3,
           "end": 471.76,
           "word": " yo,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 512,
-      "start": 471.82,
-      "end": 472.64,
-      "text": "it’s mental",
-      "words": [
+        },
         {
           "start": 471.82,
           "end": 472.42,
-          "word": " it’s"
+          "word": " it\u2019s"
         },
         {
           "start": 472.42,
@@ -14793,7 +13163,7 @@
       "id": 516,
       "start": 477.06,
       "end": 477.68,
-      "text": "And it’s been,",
+      "text": "And it\u2019s been,",
       "words": [
         {
           "start": 477.06,
@@ -14803,7 +13173,7 @@
         {
           "start": 477.42,
           "end": 477.56,
-          "word": " it’s"
+          "word": " it\u2019s"
         },
         {
           "start": 477.56,
@@ -14817,13 +13187,13 @@
     {
       "id": 517,
       "start": 477.74,
-      "end": 478.64,
-      "text": "it’s so temperamental",
+      "end": 479.34,
+      "text": "it\u2019s so temperamental It\u2019s mental",
       "words": [
         {
           "start": 477.74,
           "end": 477.9,
-          "word": " it’s"
+          "word": " it\u2019s"
         },
         {
           "start": 477.9,
@@ -14834,21 +13204,11 @@
           "start": 477.98,
           "end": 478.64,
           "word": " temperamental"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 518,
-      "start": 478.64,
-      "end": 479.34,
-      "text": "It’s mental",
-      "words": [
+        },
         {
           "start": 478.64,
           "end": 479.2,
-          "word": " It’s"
+          "word": " It\u2019s"
         },
         {
           "start": 479.2,
@@ -14977,8 +13337,8 @@
     {
       "id": 523,
       "start": 482.84,
-      "end": 484.06,
-      "text": "Trying to get all the lost bits",
+      "end": 484.44,
+      "text": "Trying to get all the lost bits of petrol",
       "words": [
         {
           "start": 482.84,
@@ -15014,17 +13374,7 @@
           "start": 483.88,
           "end": 484.06,
           "word": " bits"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 524,
-      "start": 484.06,
-      "end": 484.44,
-      "text": "of petrol",
-      "words": [
+        },
         {
           "start": 484.06,
           "end": 484.22,
@@ -15040,30 +13390,20 @@
       "instrumental": null
     },
     {
-      "id": 525,
+      "id": 526,
       "start": 484.44,
-      "end": 484.9,
-      "text": "See,",
+      "end": 485.36,
+      "text": "See, I\u2019m famous,",
       "words": [
         {
           "start": 484.44,
           "end": 484.9,
           "word": " See,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 526,
-      "start": 484.9,
-      "end": 485.36,
-      "text": "I’m famous,",
-      "words": [
+        },
         {
           "start": 484.9,
           "end": 485.0,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 485.0,
@@ -15077,8 +13417,8 @@
     {
       "id": 527,
       "start": 485.4,
-      "end": 486.48,
-      "text": "but I keep it normal still",
+      "end": 487.42,
+      "text": "but I keep it normal still Real recognizable,",
       "words": [
         {
           "start": 485.4,
@@ -15109,17 +13449,7 @@
           "start": 486.04,
           "end": 486.48,
           "word": " still"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 528,
-      "start": 486.48,
-      "end": 487.42,
-      "text": "Real recognizable,",
-      "words": [
+        },
         {
           "start": 486.48,
           "end": 486.94,
@@ -15135,10 +13465,10 @@
       "instrumental": null
     },
     {
-      "id": 529,
+      "id": 530,
       "start": 487.52,
-      "end": 488.2,
-      "text": "recognize real",
+      "end": 488.8,
+      "text": "recognize real I\u2019m so real,",
       "words": [
         {
           "start": 487.52,
@@ -15149,21 +13479,11 @@
           "start": 487.78,
           "end": 488.2,
           "word": " real"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 530,
-      "start": 488.2,
-      "end": 488.8,
-      "text": "I’m so real,",
-      "words": [
+        },
         {
           "start": 488.2,
           "end": 488.46,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 488.46,
@@ -15217,8 +13537,8 @@
     {
       "id": 532,
       "start": 489.88,
-      "end": 491.2,
-      "text": "Will recognize me when I’m 40",
+      "end": 491.94,
+      "text": "Will recognize me when I\u2019m 40 Like Shorty,",
       "words": [
         {
           "start": 489.88,
@@ -15243,23 +13563,13 @@
         {
           "start": 490.76,
           "end": 490.98,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 490.98,
           "end": 491.2,
           "word": " 40"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 533,
-      "start": 491.2,
-      "end": 491.94,
-      "text": "Like Shorty,",
-      "words": [
+        },
         {
           "start": 491.2,
           "end": 491.48,
@@ -15278,12 +13588,12 @@
       "id": 534,
       "start": 491.94,
       "end": 492.76,
-      "text": "I’ve been real from day",
+      "text": "I\u2019ve been real from day",
       "words": [
         {
           "start": 491.94,
           "end": 492.04,
-          "word": " I’ve"
+          "word": " I\u2019ve"
         },
         {
           "start": 492.04,
@@ -15343,7 +13653,7 @@
       "id": 536,
       "start": 493.56,
       "end": 494.44,
-      "text": "I don’t carry on the way",
+      "text": "I don\u2019t carry on the way",
       "words": [
         {
           "start": 493.56,
@@ -15353,7 +13663,7 @@
         {
           "start": 493.66,
           "end": 493.8,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 493.8,
@@ -15427,8 +13737,8 @@
     {
       "id": 538,
       "start": 496.12,
-      "end": 497.74,
-      "text": "When it’s 2000 and BBK?",
+      "end": 498.08,
+      "text": "When it\u2019s 2000 and BBK? Yo, yo, yo,",
       "words": [
         {
           "start": 496.12,
@@ -15438,7 +13748,7 @@
         {
           "start": 496.32,
           "end": 496.54,
-          "word": " it’s"
+          "word": " it\u2019s"
         },
         {
           "start": 496.54,
@@ -15454,47 +13764,17 @@
           "start": 497.14,
           "end": 497.74,
           "word": " BBK?"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 539,
-      "start": 497.86,
-      "end": 497.92,
-      "text": "Yo,",
-      "words": [
+        },
         {
           "start": 497.86,
           "end": 497.92,
           "word": " Yo,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 540,
-      "start": 497.92,
-      "end": 497.92,
-      "text": "yo,",
-      "words": [
+        },
         {
           "start": 497.92,
           "end": 497.92,
           "word": " yo,"
-        }
-      ],
-      "speaker": "Skepta",
-      "instrumental": null
-    },
-    {
-      "id": 541,
-      "start": 498.02,
-      "end": 498.08,
-      "text": "yo,",
-      "words": [
+        },
         {
           "start": 498.02,
           "end": 498.08,
@@ -15585,30 +13865,20 @@
       "instrumental": null
     },
     {
-      "id": 544,
+      "id": 545,
       "start": 501.0,
-      "end": 501.26,
-      "text": "land",
+      "end": 502.6,
+      "text": "land Don\u2019t try to come catch me by",
       "words": [
         {
           "start": 501.0,
           "end": 501.26,
           "word": " land"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 545,
-      "start": 501.26,
-      "end": 502.6,
-      "text": "Don’t try to come catch me by",
-      "words": [
+        },
         {
           "start": 501.26,
           "end": 501.66,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 501.66,
@@ -15645,10 +13915,10 @@
       "instrumental": null
     },
     {
-      "id": 546,
+      "id": 547,
       "start": 502.6,
-      "end": 502.86,
-      "text": "the man",
+      "end": 504.3,
+      "text": "the man You must have hijacked these in the",
       "words": [
         {
           "start": 502.6,
@@ -15659,17 +13929,7 @@
           "start": 502.64,
           "end": 502.86,
           "word": " man"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 547,
-      "start": 502.86,
-      "end": 504.3,
-      "text": "You must have hijacked these in the",
-      "words": [
+        },
         {
           "start": 502.86,
           "end": 503.26,
@@ -15710,41 +13970,21 @@
       "instrumental": null
     },
     {
-      "id": 548,
+      "id": 550,
       "start": 504.3,
-      "end": 504.52,
-      "text": "ground",
+      "end": 506.28,
+      "text": "ground What? Trust me for my lamb",
       "words": [
         {
           "start": 504.3,
           "end": 504.52,
           "word": " ground"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 549,
-      "start": 504.52,
-      "end": 505.08,
-      "text": "What?",
-      "words": [
+        },
         {
           "start": 504.52,
           "end": 505.08,
           "word": " What?"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 550,
-      "start": 505.2,
-      "end": 506.28,
-      "text": "Trust me for my lamb",
-      "words": [
+        },
         {
           "start": 505.2,
           "end": 505.56,
@@ -15777,8 +14017,8 @@
     {
       "id": 551,
       "start": 506.28,
-      "end": 507.72,
-      "text": "Mash up the whole party when I",
+      "end": 507.94,
+      "text": "Mash up the whole party when I land",
       "words": [
         {
           "start": 506.28,
@@ -15814,17 +14054,7 @@
           "start": 507.58,
           "end": 507.72,
           "word": " I"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 552,
-      "start": 507.72,
-      "end": 507.94,
-      "text": "land",
-      "words": [
+        },
         {
           "start": 507.72,
           "end": 507.94,
@@ -15837,13 +14067,13 @@
     {
       "id": 553,
       "start": 507.94,
-      "end": 509.32,
-      "text": "Don’t try to come catch me by",
+      "end": 509.62,
+      "text": "Don\u2019t try to come catch me by the man",
       "words": [
         {
           "start": 507.94,
           "end": 508.34,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 508.34,
@@ -15874,17 +14104,7 @@
           "start": 509.14,
           "end": 509.32,
           "word": " by"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 554,
-      "start": 509.32,
-      "end": 509.62,
-      "text": "the man",
-      "words": [
+        },
         {
           "start": 509.32,
           "end": 509.38,
@@ -15900,41 +14120,21 @@
       "instrumental": null
     },
     {
-      "id": 555,
+      "id": 557,
       "start": 510.64,
-      "end": 510.84,
-      "text": "Yeah,",
+      "end": 511.46,
+      "text": "Yeah, yeah, yeah",
       "words": [
         {
           "start": 510.64,
           "end": 510.84,
           "word": " Yeah,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 556,
-      "start": 510.84,
-      "end": 511.08,
-      "text": "yeah,",
-      "words": [
+        },
         {
           "start": 510.84,
           "end": 511.08,
           "word": " yeah,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 557,
-      "start": 511.08,
-      "end": 511.46,
-      "text": "yeah",
-      "words": [
+        },
         {
           "start": 511.08,
           "end": 511.46,
@@ -15948,7 +14148,7 @@
       "id": 558,
       "start": 511.46,
       "end": 512.9,
-      "text": "I don’t care what you man say",
+      "text": "I don\u2019t care what you man say",
       "words": [
         {
           "start": 511.46,
@@ -15958,7 +14158,7 @@
         {
           "start": 511.7,
           "end": 511.94,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 511.94,
@@ -15993,12 +14193,12 @@
       "id": 559,
       "start": 512.9,
       "end": 514.2,
-      "text": "I’m a bad man at the end",
+      "text": "I\u2019m a bad man at the end",
       "words": [
         {
           "start": 512.9,
           "end": 513.34,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 513.34,
@@ -16062,13 +14262,13 @@
     {
       "id": 561,
       "start": 514.64,
-      "end": 516.46,
-      "text": "I’m raving six in the morning on",
+      "end": 516.72,
+      "text": "I\u2019m raving six in the morning on a hike",
       "words": [
         {
           "start": 514.64,
           "end": 515.08,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 515.08,
@@ -16099,17 +14299,7 @@
           "start": 516.2,
           "end": 516.46,
           "word": " on"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 562,
-      "start": 516.46,
-      "end": 516.72,
-      "text": "a hike",
-      "words": [
+        },
         {
           "start": 516.46,
           "end": 516.54,
@@ -16127,13 +14317,13 @@
     {
       "id": 563,
       "start": 516.72,
-      "end": 517.9,
-      "text": "Don’t need no MDMA",
+      "end": 518.16,
+      "text": "Don\u2019t need no MDMA What?",
       "words": [
         {
           "start": 516.72,
           "end": 516.94,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 516.94,
@@ -16149,17 +14339,7 @@
           "start": 517.28,
           "end": 517.9,
           "word": " MDMA"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 564,
-      "start": 517.9,
-      "end": 518.16,
-      "text": "What?",
-      "words": [
+        },
         {
           "start": 517.9,
           "end": 518.16,
@@ -16173,7 +14353,7 @@
       "id": 565,
       "start": 518.28,
       "end": 519.6,
-      "text": "I don’t care what you man say",
+      "text": "I don\u2019t care what you man say",
       "words": [
         {
           "start": 518.28,
@@ -16183,7 +14363,7 @@
         {
           "start": 518.5,
           "end": 518.64,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 518.64,
@@ -16218,12 +14398,12 @@
       "id": 566,
       "start": 519.6,
       "end": 520.92,
-      "text": "I’m a bad man at the end",
+      "text": "I\u2019m a bad man at the end",
       "words": [
         {
           "start": 519.6,
           "end": 520.06,
-          "word": " I’m"
+          "word": " I\u2019m"
         },
         {
           "start": 520.06,
@@ -16288,12 +14468,12 @@
       "id": 568,
       "start": 521.38,
       "end": 522.18,
-      "text": "Don’t smoke weed,",
+      "text": "Don\u2019t smoke weed,",
       "words": [
         {
           "start": 521.38,
           "end": 521.74,
-          "word": " Don’t"
+          "word": " Don\u2019t"
         },
         {
           "start": 521.74,
@@ -16313,12 +14493,12 @@
       "id": 569,
       "start": 522.32,
       "end": 523.1,
-      "text": "don’t smoke cigarettes",
+      "text": "don\u2019t smoke cigarettes",
       "words": [
         {
           "start": 522.32,
           "end": 522.6,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 522.6,
@@ -16337,8 +14517,8 @@
     {
       "id": 570,
       "start": 523.1,
-      "end": 524.7,
-      "text": "You man smoke like 20 a day",
+      "end": 525.38,
+      "text": "You man smoke like 20 a day Carry on,",
       "words": [
         {
           "start": 523.1,
@@ -16374,17 +14554,7 @@
           "start": 524.54,
           "end": 524.7,
           "word": " day"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 571,
-      "start": 524.7,
-      "end": 525.38,
-      "text": "Carry on,",
-      "words": [
+        },
         {
           "start": 524.7,
           "end": 525.16,
@@ -16402,13 +14572,13 @@
     {
       "id": 572,
       "start": 525.38,
-      "end": 526.46,
-      "text": "you’ll get sent to your grave",
+      "end": 527.12,
+      "text": "you\u2019ll get sent to your grave Violent,",
       "words": [
         {
           "start": 525.38,
           "end": 525.54,
-          "word": " you’ll"
+          "word": " you\u2019ll"
         },
         {
           "start": 525.54,
@@ -16434,17 +14604,7 @@
           "start": 526.2,
           "end": 526.46,
           "word": " grave"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 573,
-      "start": 526.46,
-      "end": 527.12,
-      "text": "Violent,",
-      "words": [
+        },
         {
           "start": 526.46,
           "end": 527.12,
@@ -16457,13 +14617,13 @@
     {
       "id": 574,
       "start": 527.12,
-      "end": 528.1,
-      "text": "you’ll get sent to your grave",
+      "end": 528.5,
+      "text": "you\u2019ll get sent to your grave In fact,",
       "words": [
         {
           "start": 527.12,
           "end": 527.3,
-          "word": " you’ll"
+          "word": " you\u2019ll"
         },
         {
           "start": 527.3,
@@ -16489,17 +14649,7 @@
           "start": 527.84,
           "end": 528.1,
           "word": " grave"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 575,
-      "start": 528.1,
-      "end": 528.5,
-      "text": "In fact,",
-      "words": [
+        },
         {
           "start": 528.1,
           "end": 528.24,
@@ -16518,12 +14668,12 @@
       "id": 576,
       "start": 528.64,
       "end": 530.16,
-      "text": "you’re gonna have to work flipping hard",
+      "text": "you\u2019re gonna have to work flipping hard",
       "words": [
         {
           "start": 528.64,
           "end": 529.02,
-          "word": " you’re"
+          "word": " you\u2019re"
         },
         {
           "start": 529.02,
@@ -16562,8 +14712,8 @@
     {
       "id": 577,
       "start": 530.16,
-      "end": 531.46,
-      "text": "Do not get sent to your grave",
+      "end": 532.0,
+      "text": "Do not get sent to your grave See,",
       "words": [
         {
           "start": 530.16,
@@ -16599,17 +14749,7 @@
           "start": 531.24,
           "end": 531.46,
           "word": " grave"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 578,
-      "start": 531.46,
-      "end": 532.0,
-      "text": "See,",
-      "words": [
+        },
         {
           "start": 531.46,
           "end": 532.0,
@@ -16667,8 +14807,8 @@
     {
       "id": 580,
       "start": 533.16,
-      "end": 534.52,
-      "text": "I don’t act like I went to",
+      "end": 534.9,
+      "text": "I don\u2019t act like I went to the States",
       "words": [
         {
           "start": 533.16,
@@ -16678,7 +14818,7 @@
         {
           "start": 533.36,
           "end": 533.62,
-          "word": " don’t"
+          "word": " don\u2019t"
         },
         {
           "start": 533.62,
@@ -16704,17 +14844,7 @@
           "start": 534.36,
           "end": 534.52,
           "word": " to"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 581,
-      "start": 534.52,
-      "end": 534.9,
-      "text": "the States",
-      "words": [
+        },
         {
           "start": 534.52,
           "end": 534.62,
@@ -16732,8 +14862,8 @@
     {
       "id": 582,
       "start": 534.9,
-      "end": 536.14,
-      "text": "Go run up your macro,",
+      "end": 536.48,
+      "text": "Go run up your macro, boy",
       "words": [
         {
           "start": 534.9,
@@ -16759,17 +14889,7 @@
           "start": 535.9,
           "end": 536.14,
           "word": " macro,"
-        }
-      ],
-      "speaker": "Tempa T",
-      "instrumental": null
-    },
-    {
-      "id": 583,
-      "start": 536.22,
-      "end": 536.48,
-      "text": "boy",
-      "words": [
+        },
         {
           "start": 536.22,
           "end": 536.48,
@@ -16783,12 +14903,12 @@
       "id": 584,
       "start": 536.48,
       "end": 537.76,
-      "text": "I’ll murk you and all your friends",
+      "text": "I\u2019ll murk you and all your friends",
       "words": [
         {
           "start": 536.48,
           "end": 536.66,
-          "word": " I’ll"
+          "word": " I\u2019ll"
         },
         {
           "start": 536.66,
@@ -16853,7 +14973,7 @@
       "id": 586,
       "start": 540.64,
       "end": 541.56,
-      "text": "To Logan’s summer",
+      "text": "To Logan\u2019s summer",
       "words": [
         {
           "start": 540.64,
@@ -16863,7 +14983,7 @@
         {
           "start": 540.8,
           "end": 541.22,
-          "word": " Logan’s"
+          "word": " Logan\u2019s"
         },
         {
           "start": 541.22,
@@ -16878,7 +14998,7 @@
       "id": 587,
       "start": 541.56,
       "end": 543.26,
-      "text": "Right now you’re listening to KISS",
+      "text": "Right now you\u2019re listening to KISS",
       "words": [
         {
           "start": 541.56,
@@ -16893,7 +15013,7 @@
         {
           "start": 542.16,
           "end": 542.36,
-          "word": " you’re"
+          "word": " you\u2019re"
         },
         {
           "start": 542.36,

--- a/reform_segments.py
+++ b/reform_segments.py
@@ -1,0 +1,88 @@
+import json, sys
+
+PUNCT_END = {'.', '!', '?'}
+
+
+def split_segment(seg, max_words=9):
+    words = seg['words']
+    speaker = seg.get('speaker')
+    new_segs = []
+    buf = []
+    for w in words:
+        buf.append(w)
+        if w['word'].strip().endswith(tuple(PUNCT_END)) or len(buf) >= max_words:
+            new_segs.append(buf)
+            buf = []
+    if buf:
+        new_segs.append(buf)
+    final = []
+    for chunk in new_segs:
+        if final and len(chunk) <= 2 and len(final[-1]) + len(chunk) <= max_words:
+            final[-1].extend(chunk)
+        else:
+            final.append(chunk)
+    new_segs = final
+    result = []
+    for chunk in new_segs:
+        result.append({
+            'start': chunk[0]['start'],
+            'end': chunk[-1]['end'],
+            'text': ' '.join(w['word'] for w in chunk),
+            'words': chunk,
+            'speaker': speaker
+        })
+    return result
+
+
+def merge_orphans(segments, max_words=9):
+    i = 0
+    while i < len(segments):
+        seg = segments[i]
+        if len(seg['words']) <= 2:
+            merged = False
+            if i > 0 and segments[i-1]['speaker'] == seg['speaker'] and len(segments[i-1]['words']) + len(seg['words']) <= max_words:
+                # merge with previous
+                segments[i-1]['words'].extend(seg['words'])
+                segments[i-1]['end'] = seg['end']
+                segments[i-1]['text'] += ' ' + seg['text']
+                segments.pop(i)
+                merged = True
+            elif i+1 < len(segments) and segments[i+1]['speaker'] == seg['speaker'] and len(segments[i+1]['words']) + len(seg['words']) <= max_words:
+                # merge with next
+                segments[i+1]['words'] = seg['words'] + segments[i+1]['words']
+                segments[i+1]['start'] = seg['start']
+                segments[i+1]['text'] = seg['text'] + ' ' + segments[i+1]['text']
+                segments.pop(i)
+                merged = True
+            if merged:
+                continue
+            # attempt to borrow from previous
+            if i > 0 and segments[i-1]['speaker'] == seg['speaker'] and len(segments[i-1]['words']) > 2:
+                while len(seg['words']) < 3 and len(segments[i-1]['words']) > 3:
+                    moved = segments[i-1]['words'].pop()
+                    seg['words'].insert(0, moved)
+                    seg['start'] = moved['start']
+                    seg['text'] = ' '.join(w['word'] for w in seg['words'])
+                    segments[i-1]['end'] = segments[i-1]['words'][-1]['end']
+                    segments[i-1]['text'] = ' '.join(w['word'] for w in segments[i-1]['words'])
+        i += 1
+    return segments
+
+
+def process_file(path):
+    data = json.load(open(path))
+    new_segments = []
+    for seg in data['segments']:
+        if len(seg['words']) > 9:
+            new_segments.extend(split_segment(seg))
+        else:
+            new_segments.append(seg)
+    new_segments = merge_orphans(new_segments)
+    data['segments'] = new_segments
+    with open(path, 'w') as f:
+        json.dump(data, f, indent=2)
+    print(f"Processed {path}: segments {len(data['segments'])}")
+
+if __name__ == '__main__':
+    for file in sys.argv[1:]:
+        process_file(file)


### PR DESCRIPTION
## Summary
- split overly long transcript segments using punctuation and a ~9 word limit
- merge very short orphan segments where possible
- add a helper script `reform_segments.py` to apply these rules

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68455ecbc6488326a885c4a8f61334fb