### PR TITLE
Refactor loop functions to share update closure

### DIFF
--- a/js/ui/lyricsDisplay.js
+++ b/js/ui/lyricsDisplay.js
@@ -12,17 +12,6 @@ let rafId = null;
   let silenceActive = false;
   let lastTime = 0;
 
-  function startLoop() {
-    if (rafId === null) rafId = requestAnimationFrame(update);
-  }
-
-  function stopLoop() {
-    if (rafId !== null) {
-      cancelAnimationFrame(rafId);
-      rafId = null;
-    }
-  }
-
   loadActiveArchiveData()
   .then(json => {
     archiveData = json;
@@ -116,6 +105,17 @@ let rafId = null;
       });
 
       rafId = requestAnimationFrame(update);
+    }
+
+    function startLoop() {
+      if (rafId === null) rafId = requestAnimationFrame(update);
+    }
+
+    function stopLoop() {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
     }
 
     function resetAndUpdate() {


### PR DESCRIPTION
## Summary
- move `startLoop` and `stopLoop` into the `.then()` callback in `lyricsDisplay.js`
- ensure both functions capture `update` while leaving event listeners in place

## Testing
- `node --check js/ui/lyricsDisplay.js`

------
https://chatgpt.com/codex/tasks/task_e_6846ccf8341c8326b07b039e35fcf312