### PR TITLE
fix: resync lyrics after seeking

### DIFF
--- a/js/ui/lyricsDisplay.js
+++ b/js/ui/lyricsDisplay.js
@@ -21,6 +21,15 @@ loadActiveArchiveData()
     const infoBar = document.getElementById("infoBar");
     if (infoBar) infoBar.textContent = `Now playing: ${archiveData.title || "Archive"}`;
 
+    video.addEventListener("seeked", () => {
+      // Clear previous state when seeking to avoid desyncs
+      activeWords = new Set();
+      currentSegmentId = null;
+      lastTime = video.currentTime;
+      // Force immediate UI update
+      requestAnimationFrame(update);
+    });
+
     function update() {
       const currentTime = video.currentTime;
 

--- a/js/ui/speakerTimeline.js
+++ b/js/ui/speakerTimeline.js
@@ -143,6 +143,13 @@ loadActiveArchiveData()
       updateActiveBlocks(video.currentTime);
     });
 
+    // Ensure UI syncs exactly after manual seeking
+    video.addEventListener("seeked", () => {
+      updateLyrics(video.currentTime);
+      updateTimelineCursor(video.currentTime);
+      updateActiveBlocks(video.currentTime);
+    });
+
     let isDragging = false;
 
     timeline.addEventListener("mousedown", (e) => {


### PR DESCRIPTION
## Summary
- resync lyrics and active blocks immediately after seeking

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846d174319c8326b808e60c136346a0