### PR TITLE
Create modular thumbnail grid

### DIFF
--- a/css/grid.css
+++ b/css/grid.css
@@ -1,9 +1,9 @@
-# Grid layout for landing page
+/* Grid layout for landing page */
 
 #thumbnail-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-auto-rows: 33vh;
+    grid-template-columns: repeat(2, 1fr);
+    grid-auto-rows: 50vh;
     width: 100%;
     height: 100%;
     overflow-y: auto;

--- a/css/grid.css
+++ b/css/grid.css
@@ -1,0 +1,21 @@
+# Grid layout for landing page
+
+#thumbnail-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-rows: 33vh;
+    width: 100%;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.thumbnail-cell {
+    position: relative;
+    overflow: hidden;
+}
+
+.thumbnail-cell canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+}

--- a/css/grid.css
+++ b/css/grid.css
@@ -1,21 +1,25 @@
 /* Grid layout for landing page */
 
-#thumbnail-grid {
+#thumbnail-grid,
+.thumbnail-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-auto-rows: 50vh;
     width: 100%;
-    height: 100%;
+    grid-template-columns: repeat(2, 1fr);
+    grid-auto-rows: auto;
     overflow-y: auto;
 }
 
 .thumbnail-cell {
     position: relative;
     overflow: hidden;
-}
-
-.thumbnail-cell canvas {
     width: 100%;
     height: 100%;
+}
+
+.thumbnail-cell canvas,
+.thumbnail-cell img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
     display: block;
 }

--- a/css/grid.css
+++ b/css/grid.css
@@ -9,6 +9,14 @@
     overflow-y: auto;
 }
 
+#thumbnail-grid {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
 .thumbnail-cell {
     position: relative;
     overflow: hidden;

--- a/css/main_style.css
+++ b/css/main_style.css
@@ -33,6 +33,17 @@ body {
     /* empêche débordement visuel */
 }
 
+/* Wrapper for the landing grid */
+#wrapper_0 {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    z-index: 0;
+}
+
 #wrapper_1 {
     top: 0%;
     position: relative;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Grime Index</title>
   <link rel="stylesheet" href="css/reset.css" />
   <link rel="stylesheet" href="css/main_style.css" />
+  <link rel="stylesheet" href="css/grid.css" />
   <!-- <link rel="stylesheet" href="css/index.css" /> -->
   <!-- <link rel="stylesheet" href="css/header.css" />  --> <!-- unused -->
   <link rel="stylesheet" href="css/textAnimations.css" />
@@ -36,13 +37,8 @@
     
   <div id="main_wrapper">
     <div id="wrapper_1">
-      <!-- Canvas avec effet shader -->
-      <canvas id="video-canvas"></canvas>
-
-      <!-- Vidéo source, cachée -->
-      <video id="background-video" preload="auto" autoplay loop style="display: none;">
-        <source src="videos/VideoExports/Archive_001_LoganSama_JME_NewhamGenerals.mp4" type="video/mp4">
-      </video>
+      <!-- Grid of thumbnails -->
+      <div id="thumbnail-grid"></div>
 
       
       <!-- Modules centraux -->
@@ -95,25 +91,25 @@
     </div> <!-- Fin de wrapper 1 -->
   </div> <!-- Fin de main_wrapper -->
 
-  <!-- Active data file -->
-  <script id="active-archive" data-archive="ARCHIVE_001_data.json"></script>
+  <!-- Active data file (unused on landing) -->
+  <!-- <script id="active-archive" data-archive="ARCHIVE_001_data.json"></script> -->
 
   <!-- ==== Scripts ==== -->
   
   <!-- ==== DATA & VIDEO ==== -->
-  <script src="js/video/videoPlayer.js"></script>
-  <script type="module" src="js/data/dataLinker.js"></script>
+  <!-- <script src="js/video/videoPlayer.js"></script> -->
+  <!-- <script type="module" src="js/data/dataLinker.js"></script> -->
 
   <!-- ==== FILTRES ==== -->
   <!-- <script type="module" src="js/ui/filtreOpen.js"></script> -->
 
   <!-- ==== VISUALISER ==== -->
-  <script type="module" src="js/ui/lyricsDisplay.js"></script>
+  <!-- <script type="module" src="js/ui/lyricsDisplay.js"></script> -->
   <!-- <script type="module" src="js/ui/eventManager.js"></script>  -->
-  <script src="js/video/shader/videoShader.js"></script>
+  <!-- <script src="js/video/shader/videoShader.js"></script> -->
 
   <!-- ==== TIMELINE ==== -->
-  <script type="module" src="js/ui/speakerTimeline.js"></script>
+  <!-- <script type="module" src="js/ui/speakerTimeline.js"></script> -->
   <!-- <script type="module" src="js/audio/reactiveType/audioReactiveType_02.js"></script>  -->
   
 
@@ -125,6 +121,8 @@
   <!-- <script id="active-shader" data-shader="multi-threshold"></script> -->
   <!-- <script id="active-shader" data-shader="threshold_grey_gradient_outline"></script> -->
   <!-- Faire des nouveaux Shaders -->
+
+  <script type="module" src="js/ui/thumbnailGrid.js"></script>
 
 
   

--- a/index.html
+++ b/index.html
@@ -36,9 +36,10 @@
   </div> -->
     
   <div id="main_wrapper">
-    <div id="wrapper_1">
-      <!-- Grid of thumbnails -->
+    <div id="wrapper_0">
       <div id="thumbnail-grid"></div>
+    </div>
+    <div id="wrapper_1">
 
       
       <!-- Modules centraux -->
@@ -89,6 +90,7 @@
 
 
     </div> <!-- Fin de wrapper 1 -->
+    </div> <!-- Fin de wrapper 0 -->
   </div> <!-- Fin de main_wrapper -->
 
   <!-- Active data file (unused on landing) -->

--- a/js/ui/grid/buildThumbnail.js
+++ b/js/ui/grid/buildThumbnail.js
@@ -1,0 +1,66 @@
+async function loadShader(gl, name) {
+  const res = await fetch(`shaders/${name}.glsl`);
+  return res.text();
+}
+
+async function drawFrameToCanvas(videoSrc, canvas, shaderName = 'threshold_grey_gradient') {
+  const gl = canvas.getContext('webgl');
+  if (!gl) return;
+
+  const vertexSrc = `attribute vec2 a_position;\nattribute vec2 a_texCoord;\nvarying vec2 v_texCoord;\nvoid main(){gl_Position=vec4(a_position,0,1);v_texCoord=a_texCoord;}`;
+  const fragSrc = await loadShader(gl, shaderName);
+  const vShader = gl.createShader(gl.VERTEX_SHADER);
+  gl.shaderSource(vShader, vertexSrc);
+  gl.compileShader(vShader);
+  const fShader = gl.createShader(gl.FRAGMENT_SHADER);
+  gl.shaderSource(fShader, fragSrc);
+  gl.compileShader(fShader);
+  const program = gl.createProgram();
+  gl.attachShader(program, vShader);
+  gl.attachShader(program, fShader);
+  gl.linkProgram(program);
+  gl.useProgram(program);
+
+  const positionBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1,1,-1,-1,1,-1,1,1,-1,1,1]), gl.STATIC_DRAW);
+  const positionLoc = gl.getAttribLocation(program, 'a_position');
+  gl.enableVertexAttribArray(positionLoc);
+  gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
+
+  const texCoordBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, texCoordBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([0,1,1,1,0,0,0,0,1,1,1,0]), gl.STATIC_DRAW);
+  const texCoordLoc = gl.getAttribLocation(program, 'a_texCoord');
+  gl.enableVertexAttribArray(texCoordLoc);
+  gl.vertexAttribPointer(texCoordLoc, 2, gl.FLOAT, false, 0, 0);
+
+  const texture = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+
+  const video = document.createElement('video');
+  video.crossOrigin = 'anonymous';
+  video.src = videoSrc;
+  video.muted = true;
+  video.preload = 'auto';
+  video.addEventListener('loadedmetadata', () => {
+    const t = Math.random() * video.duration;
+    video.currentTime = t;
+  });
+  video.addEventListener('seeked', () => {
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, video);
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+  });
+}
+
+export async function buildThumbnail(archive) {
+  const cell = document.createElement('div');
+  cell.classList.add('thumbnail-cell');
+  const canvas = document.createElement('canvas');
+  cell.appendChild(canvas);
+  await drawFrameToCanvas(archive.file, canvas);
+  return cell;
+}

--- a/js/ui/grid/configureGrid.js
+++ b/js/ui/grid/configureGrid.js
@@ -1,0 +1,14 @@
+export function configureGrid(container, type = 'landing') {
+  if (!container) return;
+  let columns = 2;
+  switch (type) {
+    case 'landing':
+      columns = 2;
+      break;
+    // other types can override columns here
+    default:
+      columns = 2;
+  }
+  container.style.gridTemplateColumns = `repeat(${columns}, 1fr)`;
+  container.style.gridAutoRows = 'auto';
+}

--- a/js/ui/grid/createGrid.js
+++ b/js/ui/grid/createGrid.js
@@ -1,0 +1,5 @@
+export function createGrid(container) {
+  if (!container) return null;
+  container.classList.add('thumbnail-grid');
+  return container;
+}

--- a/js/ui/thumbnailGrid.js
+++ b/js/ui/thumbnailGrid.js
@@ -1,0 +1,98 @@
+const archives = [
+  {
+    file: "videos/Archive_001_LoganSama_JME_NewhamGenerals.mp4",
+    archive: "ARCHIVE_001_data.json",
+  },
+  {
+    file: "videos/Archive_002_DDoubleE_Footsie_LoganSama.mp4",
+    archive: "ARCHIVE_002_data.json",
+  },
+  {
+    file: "videos/Archive_003_LoganSama_Skepta_JME_Jammer_Frisco_Shorty.mp4",
+    archive: "ARCHIVE_003_data.json",
+  },
+  {
+    file: "videos/Archive_007_TempaT_Skepta_JME_LoganSama.mp4",
+    archive: "ARCHIVE_007_data.json",
+  },
+];
+
+function loadShader(gl, name) {
+  return fetch(`shaders/${name}.glsl`).then((res) => res.text());
+}
+
+async function drawFrameToCanvas(videoSrc, canvas, shaderName = "threshold_grey_gradient") {
+  const gl = canvas.getContext("webgl");
+  if (!gl) return;
+
+  const vertexSrc = `attribute vec2 a_position;\nattribute vec2 a_texCoord;\nvarying vec2 v_texCoord;\nvoid main(){gl_Position=vec4(a_position,0,1);v_texCoord=a_texCoord;}`;
+  const fragSrc = await loadShader(gl, shaderName);
+  const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+  gl.shaderSource(vertexShader, vertexSrc);
+  gl.compileShader(vertexShader);
+  const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+  gl.shaderSource(fragmentShader, fragSrc);
+  gl.compileShader(fragmentShader);
+  const program = gl.createProgram();
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.linkProgram(program);
+  gl.useProgram(program);
+
+  const positionBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]),
+    gl.STATIC_DRAW
+  );
+  const positionLoc = gl.getAttribLocation(program, "a_position");
+  gl.enableVertexAttribArray(positionLoc);
+  gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
+
+  const texCoordBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, texCoordBuffer);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0]),
+    gl.STATIC_DRAW
+  );
+  const texCoordLoc = gl.getAttribLocation(program, "a_texCoord");
+  gl.enableVertexAttribArray(texCoordLoc);
+  gl.vertexAttribPointer(texCoordLoc, 2, gl.FLOAT, false, 0, 0);
+
+  const texture = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+
+  const video = document.createElement("video");
+  video.crossOrigin = "anonymous";
+  video.src = videoSrc;
+  video.muted = true;
+  video.preload = "auto";
+  video.addEventListener("loadedmetadata", () => {
+    const t = Math.random() * video.duration;
+    video.currentTime = t;
+  });
+  video.addEventListener("seeked", () => {
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, video);
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+  });
+}
+
+export function initThumbnailGrid() {
+  const container = document.getElementById("thumbnail-grid");
+  if (!container) return;
+  archives.forEach((arch) => {
+    const cell = document.createElement("div");
+    cell.classList.add("thumbnail-cell");
+    const c = document.createElement("canvas");
+    cell.appendChild(c);
+    container.appendChild(cell);
+    drawFrameToCanvas(arch.file, c);
+  });
+}
+
+document.addEventListener("DOMContentLoaded", initThumbnailGrid);

--- a/js/ui/thumbnailGrid.js
+++ b/js/ui/thumbnailGrid.js
@@ -1,103 +1,33 @@
+import { createGrid } from './grid/createGrid.js';
+import { configureGrid } from './grid/configureGrid.js';
+import { buildThumbnail } from './grid/buildThumbnail.js';
+
 const archives = [
   {
-    file: "videos/Archive_001_LoganSama_JME_NewhamGenerals.mp4",
-    archive: "ARCHIVE_001_data.json",
+    file: 'videos/Archive_001_LoganSama_JME_NewhamGenerals.mp4',
+    archive: 'ARCHIVE_001_data.json',
   },
   {
-    file: "videos/Archive_002_DDoubleE_Footsie_LoganSama.mp4",
-    archive: "ARCHIVE_002_data.json",
+    file: 'videos/Archive_002_DDoubleE_Footsie_LoganSama.mp4',
+    archive: 'ARCHIVE_002_data.json',
   },
   {
-    file: "videos/Archive_003_LoganSama_Skepta_JME_Jammer_Frisco_Shorty.mp4",
-    archive: "ARCHIVE_003_data.json",
+    file: 'videos/Archive_003_LoganSama_Skepta_JME_Jammer_Frisco_Shorty.mp4',
+    archive: 'ARCHIVE_003_data.json',
   },
   {
-    file: "videos/Archive_007_TempaT_Skepta_JME_LoganSama.mp4",
-    archive: "ARCHIVE_007_data.json",
+    file: 'videos/Archive_007_TempaT_Skepta_JME_LoganSama.mp4',
+    archive: 'ARCHIVE_007_data.json',
   },
 ];
 
-function loadShader(gl, name) {
-  return fetch(`shaders/${name}.glsl`).then((res) => res.text());
-}
-
-async function drawFrameToCanvas(videoSrc, canvas, shaderName = "threshold_grey_gradient") {
-  const gl = canvas.getContext("webgl");
-  if (!gl) return;
-
-  const vertexSrc = `attribute vec2 a_position;\nattribute vec2 a_texCoord;\nvarying vec2 v_texCoord;\nvoid main(){gl_Position=vec4(a_position,0,1);v_texCoord=a_texCoord;}`;
-  const fragSrc = await loadShader(gl, shaderName);
-  const vertexShader = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vertexShader, vertexSrc);
-  gl.compileShader(vertexShader);
-  const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fragmentShader, fragSrc);
-  gl.compileShader(fragmentShader);
-  const program = gl.createProgram();
-  gl.attachShader(program, vertexShader);
-  gl.attachShader(program, fragmentShader);
-  gl.linkProgram(program);
-  gl.useProgram(program);
-
-  const positionBuffer = gl.createBuffer();
-  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-  gl.bufferData(
-    gl.ARRAY_BUFFER,
-    new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]),
-    gl.STATIC_DRAW
-  );
-  const positionLoc = gl.getAttribLocation(program, "a_position");
-  gl.enableVertexAttribArray(positionLoc);
-  gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
-
-  const texCoordBuffer = gl.createBuffer();
-  gl.bindBuffer(gl.ARRAY_BUFFER, texCoordBuffer);
-  gl.bufferData(
-    gl.ARRAY_BUFFER,
-    new Float32Array([0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0]),
-    gl.STATIC_DRAW
-  );
-  const texCoordLoc = gl.getAttribLocation(program, "a_texCoord");
-  gl.enableVertexAttribArray(texCoordLoc);
-  gl.vertexAttribPointer(texCoordLoc, 2, gl.FLOAT, false, 0, 0);
-
-  const texture = gl.createTexture();
-  gl.bindTexture(gl.TEXTURE_2D, texture);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-
-  const video = document.createElement("video");
-  video.crossOrigin = "anonymous";
-  video.src = videoSrc;
-  video.muted = true;
-  video.preload = "auto";
-  video.addEventListener("loadedmetadata", () => {
-    const t = Math.random() * video.duration;
-    video.currentTime = t;
-  });
-  video.addEventListener("seeked", () => {
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, video);
-    gl.drawArrays(gl.TRIANGLES, 0, 6);
-  });
-}
-
-export function initThumbnailGrid(options = {}) {
-  const { containerId = "thumbnail-grid", columns = 2, rows = 2 } = options;
-  const container = document.getElementById(containerId);
+document.addEventListener('DOMContentLoaded', async () => {
+  const container = document.getElementById('thumbnail-grid');
   if (!container) return;
-  container.style.gridTemplateColumns = `repeat(${columns}, 1fr)`;
-  container.style.gridAutoRows = `calc(100vh / ${rows})`;
-  archives.forEach((arch) => {
-    const cell = document.createElement("div");
-    cell.classList.add("thumbnail-cell");
-    const c = document.createElement("canvas");
-    cell.appendChild(c);
-    container.appendChild(cell);
-    drawFrameToCanvas(arch.file, c);
-  });
-}
-
-document.addEventListener("DOMContentLoaded", () =>
-  initThumbnailGrid({ columns: 2, rows: 2 })
-);
+  createGrid(container);
+  configureGrid(container, 'landing');
+  for (const arch of archives) {
+    const thumb = await buildThumbnail(arch);
+    container.appendChild(thumb);
+  }
+});

--- a/js/ui/thumbnailGrid.js
+++ b/js/ui/thumbnailGrid.js
@@ -82,9 +82,12 @@ async function drawFrameToCanvas(videoSrc, canvas, shaderName = "threshold_grey_
   });
 }
 
-export function initThumbnailGrid() {
-  const container = document.getElementById("thumbnail-grid");
+export function initThumbnailGrid(options = {}) {
+  const { containerId = "thumbnail-grid", columns = 2, rows = 2 } = options;
+  const container = document.getElementById(containerId);
   if (!container) return;
+  container.style.gridTemplateColumns = `repeat(${columns}, 1fr)`;
+  container.style.gridAutoRows = `calc(100vh / ${rows})`;
   archives.forEach((arch) => {
     const cell = document.createElement("div");
     cell.classList.add("thumbnail-cell");
@@ -95,4 +98,6 @@ export function initThumbnailGrid() {
   });
 }
 
-document.addEventListener("DOMContentLoaded", initThumbnailGrid);
+document.addEventListener("DOMContentLoaded", () =>
+  initThumbnailGrid({ columns: 2, rows: 2 })
+);


### PR DESCRIPTION
## Summary
- add grid layout styles
- implement modular thumbnail generator
- show thumbnails instead of single video
- comment out video playback scripts on landing page

## Testing
- `npm test` *(fails: could not find package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847fc98230483268c472f9e9b608e98