### PR TITLE
Fix pixelated thumbnails

### DIFF
--- a/css/grid.css
+++ b/css/grid.css
@@ -29,5 +29,6 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    image-rendering: auto;
     display: block;
 }

--- a/js/ui/grid/buildThumbnail.js
+++ b/js/ui/grid/buildThumbnail.js
@@ -6,6 +6,7 @@ async function loadShader(gl, name) {
 async function drawFrameToCanvas(videoSrc, canvas, shaderName = 'threshold_grey_gradient') {
   const gl = canvas.getContext('webgl');
   if (!gl) return;
+  gl.viewport(0, 0, canvas.width, canvas.height);
 
   const vertexSrc = `attribute vec2 a_position;\nattribute vec2 a_texCoord;\nvarying vec2 v_texCoord;\nvoid main(){gl_Position=vec4(a_position,0,1);v_texCoord=a_texCoord;}`;
   const fragSrc = await loadShader(gl, shaderName);
@@ -60,7 +61,18 @@ export async function buildThumbnail(archive) {
   const cell = document.createElement('div');
   cell.classList.add('thumbnail-cell');
   const canvas = document.createElement('canvas');
+  canvas.style.width = '100%';
+  canvas.style.height = '100%';
   cell.appendChild(canvas);
-  await drawFrameToCanvas(archive.file, canvas);
+  await new Promise((resolve) => {
+    requestAnimationFrame(async () => {
+      const rect = canvas.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      await drawFrameToCanvas(archive.file, canvas);
+      resolve();
+    });
+  });
   return cell;
 }


### PR DESCRIPTION
## Summary
- match canvas dimensions to display size before drawing video frame
- ensure canvas uses smooth scaling by default

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684805f8fbe4832693d07657c5efb2d8