### PR TITLE
Fix sequential thumbnail rendering and release WebGL contexts

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -75,6 +75,13 @@ html, body {
     display: block;
 }
 
+.thumbnail-cell img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
 .return-btn {
     position: absolute;
     bottom: 10px;

--- a/js/gridManager.js
+++ b/js/gridManager.js
@@ -114,13 +114,13 @@ function createSelectorCell(area, id) {
     selectorGrid.className = 'selector-grid';
     cell.appendChild(selectorGrid);
 
-    archives.forEach(async arch => {
+    for (const arch of archives) {
         const thumb = await buildThumbnail(arch, selectorGrid);
         thumb.dataset.file = arch.file;
         thumb.dataset.archive = arch.archive;
         thumb.dataset.title = arch.archive;
         thumb.addEventListener('click', () => onThumbnailClick(thumb));
-    });
+    }
 
     grid.appendChild(cell);
     return cell;


### PR DESCRIPTION
## Summary
- render thumbnails one at a time through a queue
- free WebGL context after drawing and replace canvas with an image
- loop sequentially in `gridManager`
- style images like canvases

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849f3440b588326b370da98cfa46dd7