### PR TITLE
Wrap footer and grid in main_container

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -7,6 +7,13 @@ body {
     background-color: #1e1e1e;
 }
 
+#main_container {
+    width: 100dvw;
+    height: 100dvh;
+    display: flex;
+    flex-direction: column;
+}
+
 #overall-grid {
     width: 100%;
     height: 100%;
@@ -182,6 +189,7 @@ body {
 #main_footer {
     width: 100%;
     height: auto;
+    margin-top: auto;
 }
 
 #timeline-footer {

--- a/index.html
+++ b/index.html
@@ -9,8 +9,9 @@
     <link rel="stylesheet" href="css/timeline.css">
 </head>
 <body>
-    <div id="overall-grid"></div>
-    <div id="main_footer">
+    <div id="main_container">
+        <div id="overall-grid"></div>
+        <div id="main_footer">
         <div id="timeline-footer">
             <div id="TimelineContainer">
                 <div id="TimelineLeft">
@@ -34,6 +35,7 @@
                     <button id="shader-toggle-button">FX</button>
                 </div>
             </div>
+        </div>
         </div>
     </div>
     <script type="module" src="js/gridManager.js"></script>


### PR DESCRIPTION
## Summary
- add a `#main_container` flex layout
- adjust layout styles so footer stays at the bottom
- update HTML structure to wrap existing layout in the new container

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c0a0740788326bdd60fcdb8c92166